### PR TITLE
Blocks bug

### DIFF
--- a/lib/jasmine/jasmine-1.0.1.js
+++ b/lib/jasmine/jasmine-1.0.1.js
@@ -1715,7 +1715,7 @@ jasmine.Queue.prototype.next_ = function() {
           return;
         }
 
-        if (self.blocks[self.index].abort) {
+        if (self.blocks[self.index] && self.blocks[self.index].abort) {
           self.abort = true;
         }
 


### PR DESCRIPTION
When running this test case:

```
it('should flush', function() {
    var storeIsFlushed = false;
    stores.m1nodeTest1.flush(function() {
        storeIsFlushed = true;
    });
    waitsFor(function() {
        return storeIsFlushed;
    }, 'flushing to complete', 1000);
}); 
```

I got this error:

```
if (self.blocks[self.index].abort) {
                               ^
TypeError: Cannot read property 'abort' of undefined
```

This is in a node.js script. Am I doing something wrong? Seems unlikely that it's a real bug or it would have been reported already, no?

Thanks,
Mike
