### PR TITLE
Node 0.3.x compat

### DIFF
--- a/lib/jasmine/index.js
+++ b/lib/jasmine/index.js
@@ -9,8 +9,19 @@ global.window = {
   setInterval: setInterval,
   clearInterval: clearInterval
 };
+
 var src = fs.readFileSync(filename);
-var jasmine = process.compile(src + '\njasmine;', filename);
+var jasmine;
+minorVersion = process.version.match(/\d\.(\d)\.\d/)[1]
+switch (minorVersion) {
+  case "1":
+  case "2":
+    jasmine = process.compile(src + '\njasmine;', filename);
+    break;
+  default:
+    jasmine = require('vm').runInThisContext(src + "\njasmine;", filename);
+}
+
 delete global.window;
 
 function noop(){}


### PR DESCRIPTION
Hi. I've add a node version switch which removes a out-of-date message from node (process.compile) if you're using node >= 0.3.x.

cheers, Andreas
