### PR TITLE
*experimental* at-exit support

### DIFF
--- a/lib/jasmine/index.js
+++ b/lib/jasmine/index.js
@@ -45,7 +45,7 @@ jasmine.executeSpecsInFolder = function(folder, done, isVerbose, showColors, mat
 
   for (var i = 0, len = specs.length; i < len; ++i){
     var filename = specs[i];
-    require(filename.replace(/\..*$/, ""));
+    require(filename.replace(/\.\w+$/, ""));
   }
 
   var jasmineEnv = jasmine.getEnv();

--- a/spec/nested.js/NestedSpec.js
+++ b/spec/nested.js/NestedSpec.js
@@ -1,0 +1,5 @@
+describe('jasmine-node-nested.js', function(){
+  it('should pass', function(){
+    expect(1+2).toEqual(3);
+  });
+});


### PR DESCRIPTION
I went through the exercise of re-implementing this from scratch and something important came up.  Since I did this the first time a test that uses sync jasmine features was added, which exposed a flaw in my plan.

Timers aren't allowed to be set in node at-exit:

http://nodejs.org/docs/v0.3.6/api/process.html#event_exit_

...several people are looking for a beforeExit event to be put into node for that reason.  The scuttlebutt is that this feature will make it into node 0.4:

https://github.com/ry/node/issues/issue/607

We'll see.  There are clear warnings when using jasmine-node at-exit that the feature is experimental.

I'm a collaborator, obviously, but I'd appreciate some review before merging this.
