### PR TITLE
Bugfix on wrong path assumption

### DIFF
--- a/lib/jasmine/index.js
+++ b/lib/jasmine/index.js
@@ -45,7 +45,7 @@ jasmine.executeSpecsInFolder = function(folder, done, isVerbose, showColors, mat
 
   for (var i = 0, len = specs.length; i < len; ++i){
     var filename = specs[i];
-    require(filename.replace(/\..*$/, ""));
+    require(filename.replace(/\.\w+$/, ""));
   }
 
   var jasmineEnv = jasmine.getEnv();


### PR DESCRIPTION
Hi,

```
filename.replace(/\..*$/, "") -> filename.replace(/\.\w+$/, "")
```

I've changed a regexp to be a bit more restrictive to avoid a bug when the path to the spec files contains a dot (like in a beautiful_project.js).

blambeau
