### PR TITLE
Optional specs folder

### DIFF
--- a/lib/jasmine-node/cli.js
+++ b/lib/jasmine-node/cli.js
@@ -34,7 +34,7 @@ process.argv.slice(2).forEach(function(arg){
       extentions = "js|coffee";
       break;
     case '--help':
-      sys.puts(usage);
+      help();
       process.exit(1);
       break;
     default:


### PR DESCRIPTION
In order to be able to integrate jasmine framework easily to another projects I implemented way to optionally specify the folder to use to search for specs. I've also added the usage back to clarify how that should be used.
