### PR TITLE
Fixed some issues we were having with installing the package with npm

### DIFF
--- a/lib/jasmine-node/index.js
+++ b/lib/jasmine-node/index.js
@@ -45,7 +45,7 @@ jasmine.executeSpecsInFolder = function(folder, done, isVerbose, showColors, mat
   var start = 0;
   var elapsed = 0;
   var verbose = isVerbose || false;
-  var fileMatcher = matcher || new RegExp("spec\.(js)$", "i");
+  var fileMatcher = matcher || new RegExp(".(js)$", "i");
   var colors = showColors || false;
   var specs = jasmine.getAllSpecFiles(folder, fileMatcher);
 

--- a/package.json
+++ b/package.json
@@ -19,5 +19,5 @@
 , "dependencies"  : { "coffee-script" : ">=1.0.1"}
 , "files"         : ["lib/jasmine-node/"]
 , "bin"           : "bin/jasmine-node"
-, "main"          : "jasmine-node"
+, "main"          : "lib/jasmine-node"
 }


### PR DESCRIPTION
We would get errors attempting to install this via npm using:

node: 0.5.0-pre
npm: 0.3.18

I also removed the requirement to have your file end in spec.js as this didn't seem to make much sense to me.
We have all of our jasmine tests in a folder and just existing in that folder should be requirement enough to include it.
