### PR TITLE
some more fixes to package.json (1.0.5 npm is currently broken)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
 , "maintainers"   : "Martin Häger <martin.haeger@gmail.com>"
 , "licenses"      : ["MIT"]
 , "dependencies"  : { "coffee-script" : ">=1.0.1"}
-, "files"         : ["lib/jasmine-node/"]
 , "bin"           : "bin/jasmine-node"
 , "main"          : "lib/jasmine-node"
 }


### PR DESCRIPTION
got rid of files config in package.json as it was only including the lib folder in the tarball

When I attempted to install this on some machines here it was failing and not finding the package.json in the tarball.

From what I can read (hard since I can't publish the npm ;) ) the files array will only include the listed files.  Since you follow the standard layout for a CommonJS package it should be fine to not include that config option.

I did a local npm install of this change and it looks like it works fine here.
