### PR TITLE
Catching Errors in jasmine.getAllSpecFiles

### DIFF
--- a/lib/jasmine-node/index.js
+++ b/lib/jasmine-node/index.js
@@ -65,10 +65,10 @@ jasmine.executeSpecsInFolder = function(folder, done, isVerbose, showColors, mat
   jasmineEnv.reporter = {
     log: function(str){
     },
-    
+
     reportSpecStarting: function(runner) {
     },
-    
+
     reportRunnerStarting: function(runner) {
       sys.puts('Started');
       start = Number(new Date);
@@ -142,24 +142,46 @@ jasmine.executeSpecsInFolder = function(folder, done, isVerbose, showColors, mat
 
 jasmine.getAllSpecFiles = function(dir, matcher){
   var specs = [];
-
   if (fs.statSync(dir).isFile() && dir.match(matcher)) {
     specs.push(dir);
   } else {
     var files = fs.readdirSync(dir);
     for (var i = 0, len = files.length; i < len; ++i){
       var filename = dir + '/' + files[i];
-      if (fs.statSync(filename).isFile() && filename.match(matcher)){
-        specs.push(filename);
-      }else if (fs.statSync(filename).isDirectory()){
-        var subfiles = this.getAllSpecFiles(filename, matcher);
-        subfiles.forEach(function(result){
-          specs.push(result);
-        });
-      }
+        // fs.fstatSync will pass ENOENT from stat(2) up
+        // the stack. That's not particularly useful right now,
+        // so try and continue...
+        try{
+          isFile = fs.statSync(filename).isFile();
+        }catch (err){
+          if(err.code === 'ENOENT'){
+            isFile = false;
+          }else{
+              throw err;
+          }
+        }
+        if (filename.match(matcher) && isFile){
+          specs.push(filename);
+        }else{
+          try{
+            isDir = fs.statSync(filename).isDirectory();
+          } catch (err) {
+            if(err.code === 'ENOENT'){
+              isDir = false;
+            }else{
+              throw err;
+            }
+          }
+          if (isDir){
+            var subfiles = this.getAllSpecFiles(filename, matcher);
+            subfiles.forEach(function(result){
+                specs.push(result);
+            });
+          }
+        }
+
     }
   }
-  
   return specs;
 };
 


### PR DESCRIPTION
The situation:

When I am currently editing a js file within a project in my text editor, the editor creates a temporary backup file (along the lines of .#jsonrpc_backend.js.
When I attempt to run the tests without saving the file, jasmine-node bombs out with an error [1].

This is because fs.statSync() calls stat(2), and passes exceptions from stat(2) up the stack. 

IMHO this isn't the most useful behaviour in this situation - I think you'll be far more likely to want to attempt to continue on, ignoring anything that raised ENOENT.

Have patched this in my fork by simply adding try-catch statements.

[1]
davidmiller@Dev-pc-14:~/src/thinclient$ jasmine-node .
node.js:183
        throw e; // process.nextTick error, or 'error' event on first tick
        ^
Error: ENOENT, No such file or directory '/home/davidmiller/src/thinclient/static/.#jsonrpc_backend.js'  
    at Object.statSync (fs.js:400:18)
    at Object.getAllSpecFiles (/home/davidmiller/local/node/node_modules/jasmine-node/lib/jasmine-node/index.js:151:14)  
    at Object.getAllSpecFiles (/home/davidmiller/local/node/node_modules/jasmine-node/lib/jasmine-node/index.js:154:29)  
    at Object.loadHelpersInFolder (/home/davidmiller/local/node/node_modules/jasmine-node/lib/jasmine-node/index.js:31:25)  
    at Object.<anonymous> (/home/davidmiller/local/node/node_modules/jasmine-node/lib/jasmine-ode/cli.js:42:9)  
    at Module._compile (module.js:423:26)
    at Object..js (module.js:429:10)
    at Module.load (module.js:339:31)
    at Function._load (module.js:298:12)
    at require (module.js:367:19)
