### PR TITLE
Updated README to inform users they must have the word 'spec' in their specifications.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ usage
 ------
 
 Write the specifications for your code in *.js and *.coffee files in
-the spec/ directory. You can use sub-directories to better organise
+the spec/ directory (note: your specifications must have 'spec' in the filename or jasmine-node won't find them!). You can use sub-directories to better organise
 your specs.
 
 If you have installed the npm package, you can run it with:


### PR DESCRIPTION
Added a few words to the README to let new users know about having 'spec' in the file name of their specifications.
