### PR TITLE
-m parameter for selecting spec(s) to run

### DIFF
--- a/lib/jasmine-node/cli.js
+++ b/lib/jasmine-node/cli.js
@@ -11,6 +11,7 @@ for (var key in jasmine)
 var isVerbose = false;
 var showColors = true;
 var extentions = "js";
+var match = '.'
 
 var args = process.argv.slice(2);
 
@@ -31,6 +32,10 @@ while(args.length) {
     case '--coffee':
       require('coffee-script');
       extentions = "js|coffee";
+      break;
+    case '-m':
+    case '--match':
+      match = args.shift();
       break;
     case '-i':  
     case '--include':
@@ -60,7 +65,7 @@ jasmine.executeSpecsInFolder(specFolder, function(runner, log){
   } else {
     process.exit(1);
   }
-}, isVerbose, showColors, new RegExp(".spec\\.(" + extentions + ")$", 'i'));
+}, isVerbose, showColors, new RegExp(match + "spec\\.(" + extentions + ")$", 'i'));
 
 function help(){
   sys.print([ 
@@ -69,7 +74,8 @@ function help(){
   , 'Options:'
   , '  --color            - use color coding for output'
   , '  --noColor          - do not use color coding for output'
-  , '  -i, --include DIR  - add given directory to node include paths\n'
+  , '  -m, --match REGEXP - load only specs containing "REGEXPspec"'
+  , '  -i, --include DIR  - add given directory to node include paths'
   , '  --verbose          - print extra information per each test run'
   , '  --coffee           - load coffee-script which allows execution .coffee files'
   , ''


### PR DESCRIPTION
Support '-m' parameter that can be used to run only matching spec files from the directory. Useful when writing new test cases and want to run just the one you're working on. 

Runs all files matching ".spec.js" in the folder tests

```
$ jasmine-node tests
```

Runs all files matching "demospec.js" in the folder tests

```
$ jasmine-node -m demo tests
```
