### PR TITLE
Workaround for node 0.5 compatibility, where require.paths is depricated.

### DIFF
--- a/bin/jasmine-node
+++ b/bin/jasmine-node
@@ -3,6 +3,6 @@
 var path = require('path');
 var fs   = require('fs');
 var lib  = path.join(path.dirname(fs.realpathSync(__filename)), '../lib');
-require.paths.push(lib)
+//require.paths.push(lib) // qfox: depricated.. and not really required anyways.
 
 require('jasmine-node/cli.js');


### PR DESCRIPTION
Workaround for node 0.5 compatibility, where require.paths is depricated. Also, it doesn't seem to be required but maybe some dependencies of jasmine fail so who knows.
