### PR TITLE
Workaround for node 0.5+ backwards compatibility issue with require.paths

### DIFF
--- a/bin/jasmine-node
+++ b/bin/jasmine-node
@@ -3,6 +3,6 @@
 var path = require('path');
 var fs   = require('fs');
 var lib  = path.join(path.dirname(fs.realpathSync(__filename)), '../lib');
-require.paths.push(lib)
+// require.paths.push(lib) // qfox: workaround, paths is depricated in node 0.5+
 
-require('jasmine-node/cli.js');
+require(lib+'jasmine-node/cli.js');


### PR DESCRIPTION
Workaround for node 0.5+ backwards compatibility issue with require.paths
