### PR TITLE
Output is sometimes truncated because of process.exit.

### DIFF
--- a/lib/jasmine-node/cli.js
+++ b/lib/jasmine-node/cli.js
@@ -57,13 +57,22 @@ if (!specFolder) {
   help();
 }
 
+var exitCode = 0;
+
+process.on("exit", onExit);
+
+function onExit() {
+  process.removeListener("exit", onExit);
+  process.exit(exitCode);
+}
+
 jasmine.loadHelpersInFolder(specFolder, new RegExp("[-_]helper\\.(" + extentions + ")$"));
 jasmine.executeSpecsInFolder(specFolder, function(runner, log){
   sys.print('\n');
   if (runner.results().failedCount == 0) {
-    process.exit(0);
+    exitCode = 0;
   } else {
-    process.exit(1);
+    exitCode = 1;
   }
 }, isVerbose, showColors, new RegExp(match + "spec\\.(" + extentions + ")$", 'i'));
 


### PR DESCRIPTION
process.exit doesn't wait for all pending tasks to finish. Output can get truncated. Defer using it until all tasks are done.
