### PR TITLE
patch for "jasmine.Suite() required" error 

### DIFF
--- a/lib/jasmine-node/jasmine-1.0.1.js
+++ b/lib/jasmine-node/jasmine-1.0.1.js
@@ -763,6 +763,10 @@ jasmine.Env.prototype.describe = function(description, specDefinitions) {
   this.currentSuite = parentSuite;
 
   if (declarationError) {
+    if(!this.currentSuite){
+      this.currentSuite = suite;
+    }
+
     this.it("encountered a declaration exception", function() {
       throw declarationError;
     });


### PR DESCRIPTION
So lets say I have following test: https://gist.github.com/1100808

Instead of getting error about the file not exists I'm constantly getting "jasmine.Suite() required" which says nothing.
