### PR TITLE
New fix to issue #67

### DIFF
--- a/lib/jasmine-node/reporter.js
+++ b/lib/jasmine-node/reporter.js
@@ -99,10 +99,11 @@ TerminalReporter.prototype = {
 
         spec.items_.forEach(function(result){
           if (!result.passed_) {
+			var errorMessage = result.trace.stack || result.message;
             if(outerThis.teamcity_) {
-              outerThis.log_.push("##teamcity[testFailed name='" +  escapeTeamcityString(spec.description) + "' message='[FAILED]' details='" + escapeTeamcityString(outerThis.stackFilter(outerThis.stackFilter(result.trace.stack))) + "']");
+              outerThis.log_.push("##teamcity[testFailed name='" +  escapeTeamcityString(spec.description) + "' message='[FAILED]' details='" + escapeTeamcityString(outerThis.stackFilter(outerThis.stackFilter(errorMessage))) + "']");
             } else {
-              outerThis.log_.push('  ' +  outerThis.stackFilter(result.trace.stack) + '\n');
+              outerThis.log_.push('  ' +  outerThis.stackFilter(errorMessage) + '\n');
             }
           }
         });


### PR DESCRIPTION
Now it works with
it("kaboom!", function() {
  throw "FAIL!"
});
