### PR TITLE
Better print-out of results in verbose mode

### DIFF
--- a/lib/jasmine-node/reporter.js
+++ b/lib/jasmine-node/reporter.js
@@ -61,6 +61,7 @@ TerminalReporter.prototype = {
   reportRunnerStarting: function(runner) {
     this.printLine_('Started');
     this.start_ = Number(new Date);
+		this.spec_results = '';
   },
 
   reportSuiteResults: function(suite) {
@@ -113,6 +114,7 @@ TerminalReporter.prototype = {
     } else {
       msg = this.stringWithColor_('F', this.color_.fail());
     }
+		this.spec_results += msg;
     this.print_(msg);
     if (this.columnCounter_++ < 50) return;
     this.columnCounter_ = 0;
@@ -127,6 +129,8 @@ TerminalReporter.prototype = {
     this.log_.forEach(function(entry) {
       owner.printLine_(entry);
     });
+		if(this.isVerbose_)
+			this.printLine_(this.spec_results);
     this.printLine_('Finished in ' + elapsed + ' seconds');
 
     var summary = printRunnerResults(runner);


### PR DESCRIPTION
this should separate the `Spec` blocks with newline

and add a closing `............` specResults trail above the 'Finished'
