### PR TITLE
Remove include option from CLI help output.

### DIFF
--- a/lib/jasmine-node/cli.js
+++ b/lib/jasmine-node/cli.js
@@ -119,7 +119,6 @@ function help(){
   , '  --color            - use color coding for output'
   , '  --noColor          - do not use color coding for output'
   , '  -m, --match REGEXP - load only specs containing "REGEXPspec"'
-  , '  -i, --include DIR  - add given directory to node include paths'
   , '  --verbose          - print extra information per each test run'
   , '  --coffee           - load coffee-script which allows execution .coffee files'
   , '  --junitreport      - export tests results as junitreport xml format'


### PR DESCRIPTION
Removed the `--include` option from the CLI help output, since the option itself was removed in cefebf0771769e2258277376967be788814909d2. As an aside, I'd suggest using [Semantic Versioning](http://semver.org/) and not make breaking changes in a patch release. It took me a while to figure out why `require` wasn't finding modules it had been before.
