### PR TITLE
The --include CLI option is no longer supported, so removed from help!

### DIFF
--- a/lib/jasmine-node/cli.js
+++ b/lib/jasmine-node/cli.js
@@ -119,7 +119,6 @@ function help(){
   , '  --color            - use color coding for output'
   , '  --noColor          - do not use color coding for output'
   , '  -m, --match REGEXP - load only specs containing "REGEXPspec"'
-  , '  -i, --include DIR  - add given directory to node include paths'
   , '  --verbose          - print extra information per each test run'
   , '  --coffee           - load coffee-script which allows execution .coffee files'
   , '  --junitreport      - export tests results as junitreport xml format'


### PR DESCRIPTION
The --include (or -i) CLI option is no longer supported so removing it from the help text!
