### PR TITLE
Bugfix for regex that matches specs to load

### DIFF
--- a/lib/jasmine-node/index.js
+++ b/lib/jasmine-node/index.js
@@ -73,7 +73,7 @@ jasmine.executeSpecsInFolder = function(folder,
       specs = require('./spec-collection'),
       jasmineEnv = jasmine.getEnv();
 
-  specs.load(folder, matcher);
+  specs.load(folder, fileMatcher);
 
   if(junitreport.report) {
     if(!path.existsSync(junitreport.savePath)) {


### PR DESCRIPTION
Bugfix: line 71 initialized a new variable, fileMatcher which gets set to a regular expression matching files ending in ".js" if "matcher" (an optional argument to jasmine.executeSpecsInFolder) is falsey.

However, instead of passing "fileMatcher" to specs.load, "matcher" is passed. This resulted in incorrect selection of which files to execute as spec files, in the absence of an explicit "matcher".

The fix is to pass "fileMatcher" to specs.load, instead of "matcher".
