### PR TITLE
Adding spec for reporter.js, validating object initialization

### DIFF
--- a/spec/reporter_spec.js
+++ b/spec/reporter_spec.js
@@ -1,0 +1,53 @@
+var reporter = require(__dirname + "/../lib/jasmine-node/reporter");
+
+describe('reporter', function(){
+  it('initializes print_ from config', function(){
+    config = { print: true };
+    var _reporter = new reporter.TerminalReporter(config);
+    expect(_reporter.print_).toBeTruthy();
+  });
+
+  it('initializes isVerbose_ from config', function(){
+    config = { verbose: true }
+    var _reporter = new reporter.TerminalReporter(config);
+    expect(_reporter.isVerbose_).toBeTruthy();
+  });
+
+  it('initializes onComplete_ from config', function(){
+    onCompleteFn = function() {};
+    config = { onComplete: onCompleteFn }
+    var _reporter = new reporter.TerminalReporter(config);
+    expect(_reporter.onComplete_).toEqual(onCompleteFn);
+  });
+
+  it('initializes color_ from config', function(){
+    config = { color: true }
+    var _reporter = new reporter.TerminalReporter(config);
+    expect(_reporter.color_).toEqual(ANSIColors);
+  });
+
+  it('initializes stackFilter from config', function(){
+    stackFilterFn = function() {};
+    config = { stackFilter: stackFilterFn }
+    var _reporter = new reporter.TerminalReporter(config);
+    expect(_reporter.stackFilter).toEqual(stackFilterFn);
+  });
+
+  it('initializes columnCounter_ to 0', function(){
+    config = {}
+    var _reporter = new reporter.TerminalReporter(config);
+    expect(_reporter.columnCounter_).toEqual(0);
+  });
+
+  it('initializes log_ to be an empty array', function(){
+    config = {}
+    var _reporter = new reporter.TerminalReporter(config);
+    expect(_reporter.log_.length).toEqual(0);
+  });
+
+  it('initializes start_ to 0', function(){
+    config = {}
+    var _reporter = new reporter.TerminalReporter(config);
+    expect(_reporter.start_).toEqual(0);
+  });
+});


### PR DESCRIPTION
I did not see jasmine specs around the actual application code. I started with the reporter.js file, but I think adding specs to the other files wouldn't be hard either.

I'd like to work on the reporter.js file, but before I change it I'd like to cover it with specs.
Would you take specs covering the existing code with this style?
