### PR TITLE
Fix for: Feature request: Run one spec file

### DIFF
--- a/lib/jasmine-node/spec-collection.js
+++ b/lib/jasmine-node/spec-collection.js
@@ -39,8 +39,10 @@ var collection = (function() {
       getAllSpecFiles = function(path, matcher) {
         var specs = [];
 
-        if (fs.statSync(path).isFile() && path.match(matcher)) {
-          specs.push(path);
+        if (fs.statSync(path).isFile()) {
+          if (path.match(matcher)) {
+            specs.push(path);
+          }
         } else {
           var files = fs.readdirSync(path);
 


### PR DESCRIPTION
This is a simple fix for issue https://github.com/mhevery/jasmine-node/issues/57
This allows the directory parameter to point at a single spec instead.
