### PR TITLE
Fixed a bug where "Done" callback on executeSpecsInFolder wasn't being called.

### DIFF
--- a/lib/jasmine-node/cli.js
+++ b/lib/jasmine-node/cli.js
@@ -107,12 +107,6 @@ function onExit() {
 }
 
 var onComplete = function(runner, log) {
-  util.print('\n');
-  if (runner.results().failedCount == 0) {
-    exitCode = 0;
-  } else {
-    exitCode = 1;
-  }
 };
 
 

--- a/lib/jasmine-node/reporter.js
+++ b/lib/jasmine-node/reporter.js
@@ -40,7 +40,7 @@
     this.suites_ = [];
     this.specResults_ = {};
     this.failures_ = [];
-    this.onComplete_ = config.onComplete();
+    this.onComplete_ = config.onComplete;
   }
 
   jasmineNode.TerminalReporter.prototype = {
@@ -106,7 +106,7 @@
       this.printLine_(this.stringWithColor_(this.printRunnerResults_(runner), resultColor));
 
       this.finished_ = true;
-      this.onComplete(runner);
+      this.onComplete_(runner);
     },
 
     reportFailures_: function() {


### PR DESCRIPTION
I noticed there was a bug introduced where the "done" callback parameter in the executeSpecsInFolder function was never getting called.  I put this back in.  This will help people like me that may want to run something specifically when suite of tests are done running.
