### PR TITLE
Add --matchall option to make specs not named "spec" runnable

### DIFF
--- a/lib/jasmine-node/cli.js
+++ b/lib/jasmine-node/cli.js
@@ -150,7 +150,7 @@ function help(){
   , '  --color            - use color coding for output'
   , '  --noColor          - do not use color coding for output'
   , '  -m, --match REGEXP - load only specs containing "REGEXPspec"'
-  , '  --matchall         - relax requirement of "spec" in spec file names"'
+  , '  --matchall         - relax requirement of "spec" in spec file names'
   , '  --verbose          - print extra information per each test run'
   , '  --coffee           - load coffee-script which allows execution .coffee files'
   , '  --junitreport      - export tests results as junitreport xml format'


### PR DESCRIPTION
I have used Jasmine for a couple of JavaScript projects of mine that has initially been for browsers environments only. I'm in the process of making those projects compatible with node/commonjs and running the tests with jasmine-node is perfect.

However, the tests written does not have "spec" in their filenames and I think it's already a given since they live in a spec folder. Long story made short - I prefer to keep my specs filenames without a spec postfix so I implemented this feature in jasmine-node as an optional argument --matchall to cli.js.
