### PR TITLE
"Fix" for jasmine-node "hang"

### DIFF
--- a/lib/jasmine-node/cli.js
+++ b/lib/jasmine-node/cli.js
@@ -23,6 +23,7 @@ var match = '.';
 var matchall = false;
 var autotest = false;
 var useHelpers = true;
+var forceExit = false;
 
 var junitreport = {
   report: false,
@@ -85,6 +86,9 @@ while(args.length) {
     case '--autotest':
         autotest = true;
         break;
+    case '--forceexit':
+        forceExit = true;
+        break;
     case '-h':
         help();
     default:
@@ -123,6 +127,9 @@ var onComplete = function(runner, log) {
     exitCode = 0;
   } else {
     exitCode = 1;
+  }
+  if (forceExit) {
+    process.exit(exitCode);
   }
 };
 
@@ -166,6 +173,7 @@ function help(){
   , '  --runWithRequireJs - loads all specs using requirejs instead of node\'s native require method'
   , '  --test-dir         - the absolute root directory path where tests are located'
   , '  --nohelpers        - does not load helpers.'
+  , '  --forceexit        - force exit once tests complete.'
   , '  -h, --help         - display this help and exit'
   , ''
   ].join("\n"));


### PR DESCRIPTION
Regarding https://github.com/mhevery/jasmine-node/issues/71 , I've added a --forceexit flag.  Would be awesome if you'd consider pulling this back into the main sources.

--forceexit will do a process.exit() after all tests finish, even if there are still outstanding timeouts / whatever that are keeping the node event loop alive.
