### PR TITLE
Timeouts on async tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,31 @@ indicates passing (green) or failing (red) specs
 
 Checkout spec/SampleSpecs.js to see how to use it.
 
+async tests
+-----------
+
+jasmine-node includes an alternate syntax for writing asynchronous tests. Accepting
+a done callback in the specification will trigger jasmine-node to run the test 
+asynchronously waiting until the done() callback is called.
+
+```javascript
+    it("should respond with hello world", function(done) {
+      request("http://localhost:3000/hello", function(error, response, body){
+        expect(body).toEqual("hello world");
+        done();
+      });
+    });
+```
+
+An asynchronous test will fail after 5000 ms if done() is not called. This timeout 
+can be changed by setting jasmine.DEFAULT_TIMEOUT_INTERVAL or by passing a timeout 
+interval in the specification.
+
+    it("should respond with hello world", function(done) {
+      request("http://localhost:3000/hello", function(error, response, body){
+        done();
+      }, 250);  // timeout after 250 ms
+    });
 
 development
 -----------

--- a/lib/jasmine-node/async-callback.js
+++ b/lib/jasmine-node/async-callback.js
@@ -5,20 +5,33 @@
     withoutAsync[jasmineFunction] = jasmine.Env.prototype[jasmineFunction];
     return jasmine.Env.prototype[jasmineFunction] = function() {
       var args = Array.prototype.slice.call(arguments, 0);
-      var specFunction = args.pop();
-      if (specFunction.length === 0) {
-        args.push(specFunction);
-      } else {
+      var timeout = null;
+      if (isLastArgumentATimeout(args)) {
+         timeout = args.pop();
+      }
+      if (isLastArgumentAnAsyncSpecFunction(args))
+      {
+        var specFunction = args.pop();
         args.push(function() {
-          return asyncSpec(specFunction, this);
+          return asyncSpec(specFunction, this, timeout);
         });
       }
       return withoutAsync[jasmineFunction].apply(this, args);
     };
   });
 
+  function isLastArgumentATimeout(args)
+  {
+    return args.length > 0 && (typeof args[args.length-1]) === "number";
+  }
+
+  function isLastArgumentAnAsyncSpecFunction(args)
+  {
+    return args.length > 0 && (typeof args[args.length-1]) === "function" && args[args.length-1].length > 0;
+  }
+
   function asyncSpec(specFunction, spec, timeout) {
-    if (timeout == null) timeout = 1000;
+    if (timeout == null) timeout = jasmine.DEFAULT_TIMEOUT_INTERVAL || 1000;
     var done = false;
     spec.runs(function() {
       try {

--- a/spec/async-callback_spec.js
+++ b/spec/async-callback_spec.js
@@ -17,7 +17,26 @@ describe('async-callback', function() {
 
       waitsFor(function() {
         return env.currentRunner().results().totalCount > 0;
+      }, 6000);
+
+      runs(function() {
+        expect(env.currentRunner().results().failedCount).toEqual(1);
+        expect(firstResult(env.currentRunner()).message).toMatch(/timeout/);;
       });
+    });
+
+    it("should accept timeout for individual spec", function() {
+      env.describe("it", function() {
+        env.it("doesn't wait", function(done) {
+          this.expect(1+2).toEqual(3);
+        }, 250);
+      });
+
+      env.currentRunner().execute();
+
+      waitsFor(function() {
+        return env.currentRunner().results().totalCount > 0;
+      }, 500);
 
       runs(function() {
         expect(env.currentRunner().results().failedCount).toEqual(1);
@@ -94,7 +113,7 @@ describe('async-callback', function() {
       runs(function() {
         expect(env.currentRunner().results().passedCount).toEqual(1);
       });
-    });
+      });
   });
 
   describe("afterEach", function() {


### PR DESCRIPTION
- Default timeout on asynchronous tests to use jasmines's DEFAULT_TIMEOUT_INTERVAL (5000 ms). 
- Allow timeout to be specified in the spec. 
- Add examples to README.md.
- Unit tests included
  (This is my first pull request, let me know if I am doing this correctly)

Thanks,
Brian
