### PR TITLE
need to update the prevStats with the current stats so that we process o...

### DIFF
--- a/lib/jasmine-node/autotest.js
+++ b/lib/jasmine-node/autotest.js
@@ -41,11 +41,12 @@ var watchFile = function(file, stat) {
         if(!path.existsSync(file)) {
            watcher.close();
            return;
-        }      
+        }
 
         var currStats = fs.statSync( file );
     
         if(prevStats.mtime.getTime() != currStats.mtime.getTime()) {
+            prevStats = currStats;
 
             // narrow down a pattern to reduce the specs runned
             var match = path.basename(file, path.extname(file)) + ".*";


### PR DESCRIPTION
...nly once per change (my windows 7 seems to fire twice a change event through the fs.watch() api)

Please not that in my case the two file system change events fired at the same time and there is not any synchronization happening right now. In some cases it might be that both callbacks evaluate the timestamp condition at the same time. But because it did not happen during my tests, and I think this is better than what we have, I propose this quick fix.
At least the new timestamp should be used next round, shouldnt it?
