### PR TITLE
prints stderr messages (like compilation failures) during autotest runs.

### DIFF
--- a/lib/jasmine-node/autotest.js
+++ b/lib/jasmine-node/autotest.js
@@ -17,6 +17,9 @@ var run_external = function(command, args, callback) {
     child.stdout.on('data', function(data) {
         process.stdout.write(data);
     });
+    child.stderr.on('data', function(data) {
+        process.stderr.write(data);
+    });
     if(typeof callback == 'function') {
         child.on('exit', callback);
     }


### PR DESCRIPTION
when a child process encounters errors (printed to stderror) those are not printed to the autotest process. A common use case is a compilation failure in the spec. The compile problem would be swallowed, as the child process is responsible for printing test results. as simplemost fix, the data printed to stderr of the child is also printed to stderr of the parent process.
I did not find out how I would be able to integrate a test case for this fix into the current test structure.
