### PR TITLE
add travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - 0.6
+branches:
+  only:
+    - travis

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 jasmine-node
 ======
 
+[![Build Status](https://secure.travis-ci.org/spaghetticode/jasmine-node.png)](http://travis-ci.org/spaghetticode/jasmine-node)
+
 This node.js module makes the wonderful Pivotal Lab's jasmine
 (http://github.com/pivotal/jasmine) spec framework available in
 node.js.
@@ -12,9 +14,9 @@ install
 usage
 ------
 
-Write the specifications for your code in *.js and *.coffee files in the 
-spec/ directory (note: your specification files must end with either 
-.spec.js or .spec.coffee; otherwise jasmine-node won't find them!). You 
+Write the specifications for your code in *.js and *.coffee files in the
+spec/ directory (note: your specification files must end with either
+.spec.js or .spec.coffee; otherwise jasmine-node won't find them!). You
 can use sub-directories to better organise your specs.
 
 If you have installed the npm package, you can run it with:
@@ -44,7 +46,7 @@ async tests
 -----------
 
 jasmine-node includes an alternate syntax for writing asynchronous tests. Accepting
-a done callback in the specification will trigger jasmine-node to run the test 
+a done callback in the specification will trigger jasmine-node to run the test
 asynchronously waiting until the done() callback is called.
 
 ```javascript
@@ -56,8 +58,8 @@ asynchronously waiting until the done() callback is called.
     });
 ```
 
-An asynchronous test will fail after 5000 ms if done() is not called. This timeout 
-can be changed by setting jasmine.DEFAULT_TIMEOUT_INTERVAL or by passing a timeout 
+An asynchronous test will fail after 5000 ms if done() is not called. This timeout
+can be changed by setting jasmine.DEFAULT_TIMEOUT_INTERVAL or by passing a timeout
 interval in the specification.
 
     it("should respond with hello world", function(done) {

--- a/package.json
+++ b/package.json
@@ -25,4 +25,5 @@
                     }
 , "bin"           : "bin/jasmine-node"
 , "main"          : "lib/jasmine-node"
+, "scripts"       : { "test" : "node lib/jasmine-node/cli.js spec" }
 }


### PR DESCRIPTION
I think a nice addition to the package would be travis-ci server integration so here it comes this patch that allows to run the tests after each push on github via the travis-ci hook.
Adding the "scripts" attribute to package.json also allows to run the test in the terminal by typing a simple `npm test` command.

One thing, if you decide to merge this in master you should update .travis.yml configuration in order to run the tests on the master branch instead of travis. Of course you should also add travis-ci hook to your original repo.
There is a failing spec, maybe you would want to fix it in order to display on the github page a nice green badge (you can check my travis branch to see how it would look).

If you have any question feel free to ask.. I hope to contribute more in the future :)
