### PR TITLE
Added deterministic spec file ordering when running tests.

### DIFF
--- a/lib/jasmine-node/spec-collection.js
+++ b/lib/jasmine-node/spec-collection.js
@@ -31,5 +31,10 @@ exports.load = function(loadpath, matcher) {
 };
 
 exports.getSpecs = function() {
+  // Sorts spec paths in ascending alphabetical order to be able to
+  // run tests in a deterministic order.
+  specs.sort(function(a, b) {
+    return a.path().localeCompare(b.path());
+  });
   return specs;
 };


### PR DESCRIPTION
In an ideal world, maybe all tests should be completely isolated. In the real world, sometimes tests need to be ordered. I added code that sorts the spec file paths in ascending order, so tests will at least be executed in a deterministic order. By using directory and file naming conventions it should now be possible to control the order in which spec files are processed.
