### PR TITLE
Include full suite name in failed spec description for TerminalReporter

### DIFF
--- a/lib/jasmine-node/reporter.js
+++ b/lib/jasmine-node/reporter.js
@@ -159,7 +159,7 @@
         if (result.items_[i].passed_ === false) {
           failureItem = result.items_[i];
           var failure = {
-            spec: spec.description,
+            spec: spec.suite.getFullName() + " " + spec.description,
             message: failureItem.message,
             stackTrace: failureItem.trace.stack
           }

--- a/spec/reporter_spec.js
+++ b/spec/reporter_spec.js
@@ -197,6 +197,9 @@ describe('TerminalReporter', function() {
   describe('addFailureToFailures', function() {
     it('adds message and stackTrace to failures_', function() {
       var spec = {
+        suite: {
+          getFullName: function() { return 'Suite name' }
+        },
         description: 'the spec',
         results: function() {
           var result = {
@@ -222,7 +225,7 @@ describe('TerminalReporter', function() {
       var failures = this.reporter.failures_;
       expect(failures.length).toEqual(1);
       var failure = failures[0];
-      expect(failure.spec).toEqual('the spec');
+      expect(failure.spec).toEqual('Suite name the spec');
       expect(failure.message).toEqual('the message');
       expect(failure.stackTrace).toEqual('the stack');
     });


### PR DESCRIPTION
This addresses issues #148 and #131 (dups).

Alon
