### PR TITLE
Use spec.getFullName() instead of spec.description in failure spec.

### DIFF
--- a/lib/jasmine-node/reporter.js
+++ b/lib/jasmine-node/reporter.js
@@ -159,7 +159,7 @@
         if (result.items_[i].passed_ === false) {
           failureItem = result.items_[i];
           var failure = {
-            spec: spec.description,
+            spec: spec.getFullName(),
             message: failureItem.message,
             stackTrace: failureItem.trace.stack
           }


### PR DESCRIPTION
Currently, the failure spec message only contains the description passed to the it function, 
ignoring all the descriptions the parent suites are supposed to provides.
