### PR TITLE
Fixed problem with running tests that are under a node_modules folder

### DIFF
--- a/lib/jasmine-node/spec-collection.js
+++ b/lib/jasmine-node/spec-collection.js
@@ -20,7 +20,8 @@ exports.load = function(loadpath, matcher) {
     var file = wannaBeSpecs[i];
     try {
       if (fs.statSync(file).isFile()) {
-        if (!/.*node_modules.*/.test(file) && matcher.test(path.basename(file))) {
+        if (!/.*node_modules.*/.test(path.relative(loadpath, file)) &
+            matcher.test(path.basename(file))) {
           specs.push(createSpecObj(file));
         }
       }


### PR DESCRIPTION
I needed to run tests on a installed npm package. But because there was a regexp that excluded all files that had "node_modules" in it's absolute path I couldn't run them.

I changed so that the regexp only checks against the files path relative to the given spec folder. Thus only excluding files if they are in a node_modules folder that is a subfolder of the given spec folder.
