### PR TITLE
Allow passing custom parameters to the specs

### DIFF
--- a/lib/jasmine-node/cli.js
+++ b/lib/jasmine-node/cli.js
@@ -92,6 +92,9 @@ while(args.length) {
     case '-h':
         help();
     default:
+      if (arg.match(/^--params=.*/)) {
+        break;
+      }
       if (arg.match(/^--/)) help();
       if (arg.match(/^\/.*/)) {
         specFolder = arg;


### PR DESCRIPTION
Hello,

I needed to pass some variables to one of my tests. The test was making requests to a host, but on my local machine the host was on a different port then on the machines of the other team devs. So, what I need is actually some way to pass the port via the command line. My little tweak allow the following:
jasmine-node ./tests/ --params="p 20"
Later in every of my specs I'm able to get "--params="p 20"" from process.argv.
I hope you find that helpful. It will be nice if it is available in the offical repo.
