### PR TITLE
Make jasmine.executeSpecsInFolder idempotent

### DIFF
--- a/lib/jasmine-node/index.js
+++ b/lib/jasmine-node/index.js
@@ -72,7 +72,7 @@ jasmine.executeSpecsInFolder = function(folder,
   var fileMatcher = matcher || new RegExp(".(js)$", "i"),
       colors = showColors || false,
       specs = require('./spec-collection'),
-      jasmineEnv = jasmine.getEnv();
+      jasmineEnv = jasmine.currentEnv_ = new jasmine.Env();
 
   specs.load(folder, fileMatcher);
 
@@ -110,6 +110,7 @@ jasmine.executeSpecsInFolder = function(folder,
 
     for (var i = 0, len = specsList.length; i < len; ++i) {
       var filename = specsList[i];
+      delete require.cache[filename.path()];
       require(filename.path().replace(/\.\w+$/, ""));
     }
 

--- a/lib/jasmine-node/spec-collection.js
+++ b/lib/jasmine-node/spec-collection.js
@@ -1,7 +1,7 @@
 var walkdir = require('walkdir');
 var path = require('path');
 var fs = require('fs');
-var specs = [];
+var specs;
 
 var createSpecObj = function(path, root) {
   return {
@@ -15,6 +15,7 @@ var createSpecObj = function(path, root) {
 
 exports.load = function(loadpath, matcher) {
   var wannaBeSpecs = walkdir.sync(loadpath)
+  specs = [];
 
   for (var i = 0; i < wannaBeSpecs.length; i++) {
     var file = wannaBeSpecs[i];


### PR DESCRIPTION
Necessary for rerunning tests in the same process. Useful for file
watchers.
