### PR TITLE
Allow custom window objects to be used.

### DIFF
--- a/lib/jasmine-node/index.js
+++ b/lib/jasmine-node/index.js
@@ -9,12 +9,15 @@ try {
 var path = require('path');
 
 var filename = __dirname + '/jasmine-2.0.0.rc1.js';
-global.window = {
-  setTimeout: setTimeout,
-  clearTimeout: clearTimeout,
-  setInterval: setInterval,
-  clearInterval: clearInterval
-};
+var isWindowUndefined = typeof global.window === 'undefined';
+if (isWindowUndefined) {
+  global.window = {
+    setTimeout: setTimeout,
+    clearTimeout: clearTimeout,
+    setInterval: setInterval,
+    clearInterval: clearInterval
+  };
+}
 
 var src = fs.readFileSync(filename);
 var jasmine;
@@ -28,7 +31,9 @@ switch (minorVersion) {
     jasmine = require('vm').runInThisContext(src + "\njasmine;", filename);
 }
 
-delete global.window;
+if (isWindowUndefined) {
+  delete global.window;
+}
 require("./async-callback");
 require("jasmine-reporters");
 


### PR DESCRIPTION
This allows using jasmine-node to do better testing against code that requires a DOM, such as can be provided by jsdom. Without this change, jasmine-node will always override any window object you set up prior to loading it.
