### PR TITLE
Load helper files even for an isolated spec run

### DIFF
--- a/lib/jasmine-node/cli.js
+++ b/lib/jasmine-node/cli.js
@@ -1,6 +1,7 @@
 var jasmine = require('./index');
 var util,
-    Path= require('path');
+    Path = require('path'),
+    fs = require('fs');
 try {
   util = require('util')
 } catch(e) {
@@ -134,7 +135,14 @@ var onComplete = function(runner, log) {
 };
 
 if(useHelpers){
-  jasmine.loadHelpersInFolder(specFolder,
+  var helperFolder = specFolder;
+  try {
+    var stats  = fs.lstatSync(specFolder);
+    if (stats.isFile()) {
+      helperFolder = Path.dirname(specFolder);
+    }
+  }
+  jasmine.loadHelpersInFolder(helperFolder,
                               new RegExp("helpers?\\.(" + extentions + ")$", 'i'));
 }
 


### PR DESCRIPTION
Useful when running jasmine-node behind a file watcher such that only a modified file is tested.
