### PR TITLE
fixes instanceof issue in reporter_spec.js when run with requireJs 

### DIFF
--- a/spec/reporter_spec.js
+++ b/spec/reporter_spec.js
@@ -83,7 +83,7 @@ describe('TerminalReporter', function() {
     });
 
     it('sets the startedAt field', function() {
-      // instanceof does not work cross-context
+      // instanceof does not work cross-context (such as when run with requirejs)
       var ts = Object.prototype.toString;
       expect(ts.call(this.reporter.startedAt)).toBe(ts.call(new Date()));
     });


### PR DESCRIPTION
When running ./spec.sh on my system, I get this output at the end:

```
Running all tests located in the spec directory with requirejs option
node lib/jasmine-node/cli.js --runWithRequireJs ./
.........F...........F...................

Failures:

  1) should report failure (THIS IS EXPECTED)
   Message:
     Expected true to be falsy.
   Stacktrace:
     Error: Expected true to be falsy.
    at new jasmine.ExpectationResult (/Users/nathan/jasmine-node/lib/jasmine-node/jasmine-2.0.0.rc1.js:102:32)
    at null.toBeFalsy (/Users/nathan/jasmine-node/lib/jasmine-node/jasmine-2.0.0.rc1.js:1171:29)
    at null.<anonymous> (/Users/nathan/jasmine-node/spec/nested/uber-nested/UberNestedSpec.js:8:20)
    at jasmine.Block.execute (/Users/nathan/jasmine-node/lib/jasmine-node/jasmine-2.0.0.rc1.js:1001:15)
    at jasmine.Queue.next_ (/Users/nathan/jasmine-node/lib/jasmine-node/jasmine-2.0.0.rc1.js:1790:31)
    at jasmine.Queue.start (/Users/nathan/jasmine-node/lib/jasmine-node/jasmine-2.0.0.rc1.js:1743:8)
    at jasmine.Spec.execute (/Users/nathan/jasmine-node/lib/jasmine-node/jasmine-2.0.0.rc1.js:2070:14)
    at jasmine.Queue.next_ (/Users/nathan/jasmine-node/lib/jasmine-node/jasmine-2.0.0.rc1.js:1790:31)
    at jasmine.Queue.start (/Users/nathan/jasmine-node/lib/jasmine-node/jasmine-2.0.0.rc1.js:1743:8)
    at jasmine.Suite.execute (/Users/nathan/jasmine-node/lib/jasmine-node/jasmine-2.0.0.rc1.js:2215:14)

  2) sets the startedAt field
   Message:
     Expected false to be truthy.
   Stacktrace:
     Error: Expected false to be truthy.
    at new jasmine.ExpectationResult (/Users/nathan/jasmine-node/lib/jasmine-node/jasmine-2.0.0.rc1.js:102:32)
    at null.toBeTruthy (/Users/nathan/jasmine-node/lib/jasmine-node/jasmine-2.0.0.rc1.js:1171:29)
    at beforeEach.spec.id (/Users/nathan/jasmine-node/spec/reporter_spec.js:86:55)
    at jasmine.Block.execute (/Users/nathan/jasmine-node/lib/jasmine-node/jasmine-2.0.0.rc1.js:1001:15)
    at jasmine.Queue.next_ (/Users/nathan/jasmine-node/lib/jasmine-node/jasmine-2.0.0.rc1.js:1790:31)
    at jasmine.Queue.start (/Users/nathan/jasmine-node/lib/jasmine-node/jasmine-2.0.0.rc1.js:1743:8)
    at jasmine.Spec.execute (/Users/nathan/jasmine-node/lib/jasmine-node/jasmine-2.0.0.rc1.js:2070:14)
    at jasmine.Queue.next_ (/Users/nathan/jasmine-node/lib/jasmine-node/jasmine-2.0.0.rc1.js:1790:31)
    at jasmine.Queue.start (/Users/nathan/jasmine-node/lib/jasmine-node/jasmine-2.0.0.rc1.js:1743:8)
    at jasmine.Suite.execute (/Users/nathan/jasmine-node/lib/jasmine-node/jasmine-2.0.0.rc1.js:2215:14)

Finished in 5.497 seconds
41 tests, 76 assertions, 2 failures



real    0m5.818s
user    0m0.286s
sys 0m0.062s
--- Should have 41 tests and 76 assertions and 1 Failure. ---
```

This is because the `TerminalReporter > when report runner starts > sets the startedAt field` test uses instanceof,  but instanceof does not work cross-domain (or in this case, cross-vm-context)
