### PR TITLE
Adding afterEach to the context created when using RequireJS to load specs

### DIFF
--- a/lib/jasmine-node/requirejs-runner.js
+++ b/lib/jasmine-node/requirejs-runner.js
@@ -12,6 +12,7 @@ exports.executeJsRunner = function(specCollection, done, jasmineEnv) {
           xdescribe: xdescribe,
           xit: xit,
           beforeEach: beforeEach,
+          afterEach: afterEach,
           spyOn: spyOn,
           waitsFor: waitsFor,
           runs: runs,


### PR DESCRIPTION
I noticed that afterEach was not added in the buildNewContext method in requirejs-runner.js, so I added it!
