### PR TITLE
Follow symlinks when discovering specs.

### DIFF
--- a/lib/jasmine-node/spec-collection.js
+++ b/lib/jasmine-node/spec-collection.js
@@ -14,7 +14,7 @@ var createSpecObj = function(path, root) {
 };
 
 exports.load = function(loadpath, matcher) {
-  var wannaBeSpecs = walkdir.sync(loadpath)
+  var wannaBeSpecs = walkdir.sync(loadpath, { follow_symlinks: true })
   specs = [];
 
   for (var i = 0; i < wannaBeSpecs.length; i++) {


### PR DESCRIPTION
This was the behavior before commit 0b91da1be957a36d10d2b33fb1f01b57d345c21b when jasmine-node switched to using walkdir instead of findit. We were relying on it following symlinks, and I don't see any particular reason /not/ to, so this change turns that back on.
