### PR TITLE
Prevent creating a new jasmine env

### DIFF
--- a/lib/jasmine-node/index.js
+++ b/lib/jasmine-node/index.js
@@ -79,7 +79,7 @@ jasmine.executeSpecsInFolder = function(options){
   var fileMatcher = matcher || new RegExp(".(js)$", "i"),
       colors = showColors || false,
       specs = require('./spec-collection'),
-      jasmineEnv = jasmine.currentEnv_ = new jasmine.Env();
+      jasmineEnv = jasmine.getEnv();
 
   specs.load(folder, fileMatcher);
 


### PR DESCRIPTION
I need to add a custom reporter and the line 82 of lib/jasmine-node/index.js create a new jasmine env each time executeSpecsInFolder is called.
So I changed jasmineEnv = jasmine.currentEnv_ = new jasmine.Env() to jasmineEnv = jasmine.getEnv()
