### PR TITLE
handle uncaughtException events when using the CLI

### DIFF
--- a/lib/jasmine-node/cli.js
+++ b/lib/jasmine-node/cli.js
@@ -126,6 +126,12 @@ if (autotest) {
 
 var exitCode = 0;
 
+process.on('uncaughtException', function(e) {
+  console.error(e.stack || e);
+  exitCode = 1;
+  process.exit(exitCode);
+});
+
 process.on("exit", onExit);
 
 function onExit() {


### PR DESCRIPTION
We had an issue where one of our spec files (coffee) had a bad require statement.  That resulted in an exception that was never caught, and jasmine-node exited with status code 0.

This commit adds an uncaughtException handler that will log the error and exit with status code 1.

Feedback welcome!
--Bob
