### PR TITLE
Add --config parameter to command line interface

### DIFF
--- a/lib/jasmine-node/cli.js
+++ b/lib/jasmine-node/cli.js
@@ -109,6 +109,11 @@ while(args.length) {
     case '--captureExceptions':
         captureExceptions = true;
         break;
+    case '--config':
+        var configKey = args.shift();
+        var configValue = args.shift();
+        process.env[configKey]=configValue;
+        break;
     case '-h':
         help();
     default:


### PR DESCRIPTION
The config option is to allow passing values into the process.env of the test environment when started.  The idea is to allow for some variance inside of the environment that can be test-specific.  For example, code may travel from dev to qa to prod, and it would be good to be able to run the same tests in all 3 environments but all 3 environments have their own servers to deal with.  It would be nice to make the server URI, time-out settings, variable etc. variable and populate it via the command line.  Each environment can have its own .bat/.sh file to initiate the tests with environment specific values.  It follows the dir command line pattern that was already there.
