### PR TITLE
Disabling the stack trace and reversing the coffee|js search pattern

### DIFF
--- a/lib/jasmine-node/cli.js
+++ b/lib/jasmine-node/cli.js
@@ -32,6 +32,7 @@ var autotest = false;
 var useHelpers = true;
 var forceExit = false;
 var captureExceptions = false;
+var includeStackTrace = true;
 
 var junitreport = {
   report: false,
@@ -108,6 +109,9 @@ while(args.length) {
         break;
     case '--captureExceptions':
         captureExceptions = true;
+        break;
+    case '--noStack':
+        includeStackTrace = false;
         break;
     case '--config':
         var configKey = args.shift();
@@ -193,7 +197,8 @@ var options = {
   teamcity:     teamcity,
   useRequireJs: useRequireJs,
   regExpSpec:   regExpSpec,
-  junitreport:  junitreport
+  junitreport:  junitreport,
+  includeStackTrace: includeStackTrace
 }
 
 jasmine.executeSpecsInFolder(options);

--- a/lib/jasmine-node/index.js
+++ b/lib/jasmine-node/index.js
@@ -8,7 +8,7 @@ try {
 
 var path = require('path');
 
-var filename = __dirname + '/jasmine-1.3.1.js';
+var filename = path.join(__dirname, 'jasmine-1.3.1.js');
 var isWindowUndefined = typeof global.window === 'undefined';
 if (isWindowUndefined) {
   global.window = {
@@ -29,7 +29,7 @@ if (isWindowUndefined) {
   delete global.window;
 }
 require("./async-callback");
-require("jasmine-reporters");
+//require("jasmine-reporters");
 var nodeReporters = require('./reporter').jasmineNode;
 jasmine.TerminalVerboseReporter = nodeReporters.TerminalVerboseReporter;
 jasmine.TerminalReporter = nodeReporters.TerminalReporter;
@@ -76,7 +76,8 @@ jasmine.executeSpecsInFolder = function(options){
   var teamcity =     options['teamcity'];
   var useRequireJs = options['useRequireJs'];
   var matcher =      options['regExpSpec'];
-  var junitreport =  options['junitreport'];
+  var junitreport = options['junitreport'];
+  var includeStackTrace = options['includeStackTrace'];
                                           
   // Overwriting it allows us to handle custom async specs
   it = function(desc, func, timeout) {
@@ -112,7 +113,8 @@ jasmine.executeSpecsInFolder = function(options){
                                                          stackFilter: removeJasmineFrames}));
   } else {
     jasmineEnv.addReporter(new jasmine.TerminalReporter({print:       util.print,
-                                                 color:       showColors,
+                                                 color: showColors,
+                                                 includeStackTrace: includeStackTrace,
                                                  onComplete:  done,
                                                  stackFilter: removeJasmineFrames}));
   }

--- a/lib/jasmine-node/reporter.js
+++ b/lib/jasmine-node/reporter.js
@@ -28,6 +28,7 @@
     this.suites_ = [];
     this.specResults_ = {};
     this.failures_ = [];
+    this.includeStackTrace_ = config.includeStackTrace === false ?  false : true;
   }
 
 
@@ -125,8 +126,10 @@
         this.printLine_('  ' + (i + 1) + ') ' + failure.spec);
         this.printLine_('   Message:');
         this.printLine_('     ' + this.stringWithColor_(failure.message, this.color_.fail()));
-        this.printLine_('   Stacktrace:');
-        this.print_('     ' + failure.stackTrace);
+        if (this.includeStackTrace_) {
+            this.printLine_('   Stacktrace:');
+            this.print_('     ' + failure.stackTrace);
+        }
       }
     },
 


### PR DESCRIPTION
I added a --noStack variable to the command line.  It will not print out the stack trace if included.  I pass the appropriate variable via the config and options objects to follow the current implementation.

I had the array and search patterns reverse when coffee files are included.  I think this should make jasmine-node find the coffee version of a file first, and skip the compiled js version.  I have no way to test that at the moment.  Although, I am open to suggestions on how to.

Also, one minor change to use path.join in the filename variable to make the file search platform independent.

The code passed all unit tests in the specs.sh file.
