### PR TITLE
Added --noStrack command line option

### DIFF
--- a/lib/jasmine-node/cli.js
+++ b/lib/jasmine-node/cli.js
@@ -32,6 +32,7 @@ var autotest = false;
 var useHelpers = true;
 var forceExit = false;
 var captureExceptions = false;
+var includeStackTrace = true;
 
 var junitreport = {
   report: false,
@@ -108,6 +109,9 @@ while(args.length) {
         break;
     case '--captureExceptions':
         captureExceptions = true;
+        break;
+    case '--noStack':
+        includeStackTrace = false;
         break;
     case '--config':
         var configKey = args.shift();
@@ -192,7 +196,8 @@ var options = {
   teamcity:     teamcity,
   useRequireJs: useRequireJs,
   regExpSpec:   regExpSpec,
-  junitreport:  junitreport
+  junitreport:  junitreport,
+  includeStackTrace: includeStackTrace
 }
 
 jasmine.executeSpecsInFolder(options);

--- a/lib/jasmine-node/index.js
+++ b/lib/jasmine-node/index.js
@@ -76,7 +76,8 @@ jasmine.executeSpecsInFolder = function(options){
   var teamcity =     options['teamcity'];
   var useRequireJs = options['useRequireJs'];
   var matcher =      options['regExpSpec'];
-  var junitreport =  options['junitreport'];
+  var junitreport = options['junitreport'];
+  var includeStackTrace = options['includeStackTrace'];
                                           
   // Overwriting it allows us to handle custom async specs
   it = function(desc, func, timeout) {
@@ -112,9 +113,10 @@ jasmine.executeSpecsInFolder = function(options){
                                                          stackFilter: removeJasmineFrames}));
   } else {
     jasmineEnv.addReporter(new jasmine.TerminalReporter({print:       util.print,
-                                                 color:       showColors,
-                                                 onComplete:  done,
-                                                 stackFilter: removeJasmineFrames}));
+                                                color: showColors,
+                                                includeStackTrace: includeStackTrace,
+                                                onComplete:  done,
+                                                stackFilter: removeJasmineFrames}));
   }
 
   if (useRequireJs) {

--- a/lib/jasmine-node/reporter.js
+++ b/lib/jasmine-node/reporter.js
@@ -28,6 +28,7 @@
     this.suites_ = [];
     this.specResults_ = {};
     this.failures_ = [];
+    this.includeStackTrace_ = config.includeStackTrace === false ? false : true;
   }
 
 
@@ -125,8 +126,10 @@
         this.printLine_('  ' + (i + 1) + ') ' + failure.spec);
         this.printLine_('   Message:');
         this.printLine_('     ' + this.stringWithColor_(failure.message, this.color_.fail()));
-        this.printLine_('   Stacktrace:');
-        this.print_('     ' + failure.stackTrace);
+        if (this.includeStackTrace_) {
+            this.printLine_('   Stacktrace:');
+            this.print_('     ' + failure.stackTrace);
+        }
       }
     },
 


### PR DESCRIPTION
Using --noStack will display the failure message only, and will not
output the stack.  This applies only to the default terminal reporter.
