### PR TITLE
TeamcityReporter is unused

### DIFF
--- a/lib/jasmine-node/index.js
+++ b/lib/jasmine-node/index.js
@@ -102,10 +102,7 @@ jasmine.executeSpecsInFolder = function(options){
   }
 
   if(teamcity){
-    jasmineEnv.addReporter(new jasmine.TerminalReporter({print:       util.print,
-                                                 color:       false,
-                                                 onComplete:  done,
-                                                 stackFilter: removeJasmineFrames}));
+    jasmineEnv.addReporter(new jasmine.TeamcityReporter());
   } else if(isVerbose) {
     jasmineEnv.addReporter(new jasmine.TerminalVerboseReporter({ print:       util.print,
                                                          color:       showColors,


### PR DESCRIPTION
The TeamcityReporter is not used due to #134, but #136 addressed the deficiency that #134  worked around. It's time to revert #134.
