### PR TITLE
Fix broken fs.existsSync call when running on node 0.6

### DIFF
--- a/lib/jasmine-node/cli.js
+++ b/lib/jasmine-node/cli.js
@@ -139,7 +139,7 @@ if (specFolders.length === 0) {
 } else {
   // Check to see if all our files exist
   for (var idx = 0; idx < specFolders.length; idx++) {
-    if (!fs.existsSync(specFolders[idx])) {
+    if (!existsSync(specFolders[idx])) {
         console.log("File: " + specFolders[idx] + " is missing.");
         return;
     }


### PR DESCRIPTION
The existsSync method was correctly defined with `fs.existsSync || Path.existsSync` but there was a remaining call to `fs.existsSync`
