### PR TITLE
Specify single homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,7 @@
   "contributors": [
     "Chris Moultrie <chris@moultrie.org>"
   ],
-  "homepage": [
-    "http://pivotal.github.com/jasmine",
-    "https://github.com/mhevery/jasmine-node"
-  ],
+  "homepage": "https://github.com/mhevery/jasmine-node",
   "repository": {
     "type": "git",
     "url": "https://github.com/mhevery/jasmine-node.git"


### PR DESCRIPTION
Noticing the following warning on npm `1.2.21`:

```
npm WARN package.json jasmine-node@1.7.1 homepage field must be a string url. Deleted.
```
