### PR TITLE
Added check for invalid regexes

### DIFF
--- a/lib/jasmine-node/cli.js
+++ b/lib/jasmine-node/cli.js
@@ -210,7 +210,12 @@ if(useHelpers){
   })
 }
 
-var regExpSpec = new RegExp(match + (matchall ? "" : "spec\\.") + "(" + extentions + ")$", 'i')
+try {
+  var regExpSpec = new RegExp(match + (matchall ? "" : "spec\\.") + "(" + extentions + ")$", 'i')
+} catch (error) {
+  console.error("Failed to build spec-matching regex: " + error);
+  process.exit(2);
+}
 
 
 var options = {


### PR DESCRIPTION
Currently if you use the --match command-line parameter with an invalid regex jasmine-node silently fails to do anything. Instead this now detects that, and reports the error.
