### PR TITLE
Timeout handling between Async and Non Async calls is not consistent

### DIFF
--- a/lib/jasmine-node/async-callback.js
+++ b/lib/jasmine-node/async-callback.js
@@ -38,7 +38,7 @@
     }
 
     function asyncSpec(specFunction, spec, timeout) {
-        if (timeout == null) timeout = jasmine.DEFAULT_TIMEOUT_INTERVAL || 1000;
+        if (timeout == null) timeout = jasmine.getEnv().defaultTimeoutInterval || 1000;
         var done = false;
         spec.runs(function() {
             try {


### PR DESCRIPTION
When attempting to set the default timeout interval for jasmine-node, I currently need to set both of the following values.  

jasmine.getEnv().defaultTimeoutInterval = 15000;
jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;

This is caused by the fact that the async-callback.js (line 41) code refers the 'DEFAULT_TIMEOUT_INTERVAL', while the rest of the jasmine code refers to the getEnv().defaultTimeoutInterval.  

This change uses getEnv().defaultTimeoutInterval so that it is only required to set this value one time for a group of tests.
