### PR TITLE
Add skipped count to reporter output

### DIFF
--- a/lib/jasmine-node/reporter.js
+++ b/lib/jasmine-node/reporter.js
@@ -46,12 +46,14 @@
     ANSIColors: {
         pass:    function() { return '\033[32m'; }, // Green
         fail:    function() { return '\033[31m'; }, // Red
+        ignore:  function() { return '\033[37m'; }, // Light Gray
         neutral: function() { return '\033[0m';  }  // Normal
     },
 
     NoColors: {
         pass:    function() { return ''; },
         fail:    function() { return ''; },
+        ignore:  function() { return ''; },
         neutral: function() { return ''; }
     },
 
@@ -140,10 +142,10 @@
     reportSpecResults: function(spec) {
       var result = spec.results();
       var msg = '';
-      if (result.passed()) {
+      if (result.skipped) {
+        msg = this.stringWithColor_('-', this.color_.ignore());
+      } else if (result.passed()) {
         msg = this.stringWithColor_('.', this.color_.pass());
-        //      } else if (result.skipped) {  TODO: Research why "result.skipped" returns false when "xit" is called on a spec?
-        //        msg = (colors) ? (ansi.yellow + '*' + ansi.none) : '*';
       } else {
         msg = this.stringWithColor_('F', this.color_.fail());
         this.addFailureToFailures_(spec);
@@ -176,9 +178,17 @@
       var results = runner.results();
       var specs = runner.specs();
       var msg = '';
-      msg += specs.length + ' test' + ((specs.length === 1) ? '' : 's') + ', ';
+      var skippedCount = 0;
+      specs.forEach(function(spec) {
+        if (spec.results().skipped) {
+          skippedCount++;
+        }
+      });
+      var passedCount = specs.length - skippedCount;
+      msg += passedCount + ' test' + ((passedCount === 1) ? '' : 's') + ', ';
       msg += results.totalCount + ' assertion' + ((results.totalCount === 1) ? '' : 's') + ', ';
-      msg += results.failedCount + ' failure' + ((results.failedCount === 1) ? '' : 's') + '\n';
+      msg += results.failedCount + ' failure' + ((results.failedCount === 1) ? '' : 's') + ', ';
+      msg += skippedCount + ' skipped' + '\n';
       return msg;
     },
 

--- a/spec/reporter_spec.js
+++ b/spec/reporter_spec.js
@@ -251,7 +251,15 @@ describe('TerminalReporter', function() {
         },
         specs: function() {
           var _specs = new Array();
-          _specs.push(1);
+          spec = {
+            results: function() {
+              var _results = {
+                skipped: false
+              }
+              return _results;
+            }
+          };
+          _specs.push(spec);
           return _specs;
         }
       };
@@ -259,7 +267,7 @@ describe('TerminalReporter', function() {
 
     it('uses the specs\'s length, totalCount and failedCount', function() {
       var message = this.reporter.printRunnerResults_(this.runner);
-      expect(message).toEqual('1 test, 23 assertions, 52 failures\n');
+      expect(message).toEqual('1 test, 23 assertions, 52 failures, 0 skipped\n');
     });
   });
 


### PR DESCRIPTION
- Adds a dash (-) for skipped specs in light gray to the output
- Adds the total skipped to the summary message

Potential fix for #222 
