### PR TITLE
Add back use of stack filter

### DIFF
--- a/lib/jasmine-node/index.js
+++ b/lib/jasmine-node/index.js
@@ -60,6 +60,10 @@ jasmine.loadHelpersInFolder=function(folder, matcher)
 };
 
 function removeJasmineFrames(text) {
+  if (!text) {
+    return text;
+  }
+
   var lines = [];
   text.split(/\n/).forEach(function(line){
     if (line.indexOf(filename) == -1) {

--- a/lib/jasmine-node/reporter.js
+++ b/lib/jasmine-node/reporter.js
@@ -29,6 +29,7 @@
     this.specResults_ = {};
     this.failures_ = [];
     this.includeStackTrace_ = config.includeStackTrace === false ? false : true;
+    this.stackFilter_ = config.stackFilter || function(t) { return t; };
   }
 
 
@@ -130,7 +131,7 @@
         this.printLine_('     ' + this.stringWithColor_(failure.message, this.color_.fail()));
         if (this.includeStackTrace_) {
             this.printLine_('   Stacktrace:');
-            this.print_('     ' + failure.stackTrace);
+            this.print_('     ' + this.stackFilter_(failure.stackTrace));
         }
       }
     },


### PR DESCRIPTION
It looks like the using stack filter that removed jasmine frames was removed from `reporter.js` in commit https://github.com/mhevery/jasmine-node/commit/0c1e35836d3f1d14f98e4bd9b12ff22fa8801aae even though the option was still being passed in from `index.js`.

I'm not sure if this was intentional or unintentional but it I added it back since it dramatically decreases the amount of output noise when failures occur.
# New failure output

```
Failures:

  1) it works
   Message:
     Expected 1 to be 2.
   Stacktrace:
     Error: Expected 1 to be 2.
    at null.<anonymous> (/Users/kevin/github/jasmine-focused/spec/a-spec.js:3:15)

Finished in 0.014 seconds
```
# Previous failure output

```
Failures:

  1) it works
   Message:
     Expected 1 to be 2.
   Stacktrace:
     Error: Expected 1 to be 2.
    at new jasmine.ExpectationResult (/Users/kevin/github/jasmine-focused/node_modules/jasmine-node/lib/jasmine-node/jasmine-1.3.1.js:114:32)
    at null.toBe (/Users/kevin/github/jasmine-focused/node_modules/jasmine-node/lib/jasmine-node/jasmine-1.3.1.js:1235:29)
    at null.<anonymous> (/Users/kevin/github/jasmine-focused/spec/a-spec.js:3:15)
    at jasmine.Block.execute (/Users/kevin/github/jasmine-focused/node_modules/jasmine-node/lib/jasmine-node/jasmine-1.3.1.js:1064:17)
    at jasmine.Queue.next_ (/Users/kevin/github/jasmine-focused/node_modules/jasmine-node/lib/jasmine-node/jasmine-1.3.1.js:2096:31)
    at jasmine.Queue.start (/Users/kevin/github/jasmine-focused/node_modules/jasmine-node/lib/jasmine-node/jasmine-1.3.1.js:2049:8)
    at jasmine.Spec.execute (/Users/kevin/github/jasmine-focused/node_modules/jasmine-node/lib/jasmine-node/jasmine-1.3.1.js:2376:14)
    at jasmine.Queue.next_ (/Users/kevin/github/jasmine-focused/node_modules/jasmine-node/lib/jasmine-node/jasmine-1.3.1.js:2096:31)
    at jasmine.Queue.start (/Users/kevin/github/jasmine-focused/node_modules/jasmine-node/lib/jasmine-node/jasmine-1.3.1.js:2049:8)
    at jasmine.Suite.execute (/Users/kevin/github/jasmine-focused/node_modules/jasmine-node/lib/jasmine-node/jasmine-1.3.1.js:2521:14)

Finished in 0.014 seconds
```
