### PR TITLE
Keep autotesting until all tests have passed

### DIFF
--- a/lib/jasmine-node/autotest.js
+++ b/lib/jasmine-node/autotest.js
@@ -27,13 +27,13 @@ var run_external = function(command, args, callback) {
     }
 }
 
-var last_run_succesful = false;
+var last_run_successful = false;
 
 var run_everything = function() {
     // run the suite when it starts
     var argv = [].concat(baseArgv);
     run_external(argv.shift(), argv, function (code) {
-        last_run_succesful = code === 0
+        last_run_successful = code === 0
     });
 }
 
@@ -62,11 +62,11 @@ exports.start = function(loadpaths, watchFolders, patterns) {
         run_external(argv.shift(), argv, function(code) {
             // run everything if we fixed some bugs
             if(code == 0) {
-                if(!last_run_succesful) {
+                if(!last_run_successful) {
                     run_everything();
                 }
             } else {
-                last_run_succesful = false;
+                last_run_successful = false;
             }
         });
       }


### PR DESCRIPTION
There are cases where there are broken tests in a spec, but they don't get run after fixing tests in a different spec. This leads to the latest result being green, even though there are failing tests.
