### PR TITLE
Catch errors when loading helpers

### DIFF
--- a/lib/jasmine-node/index.js
+++ b/lib/jasmine-node/index.js
@@ -36,26 +36,34 @@ jasmine.TerminalVerboseReporter = nodeReporters.TerminalVerboseReporter;
 jasmine.TerminalReporter = nodeReporters.TerminalReporter;
 
 
-jasmine.loadHelpersInFolder=function(folder, matcher)
-{
+jasmine.loadHelpersInFolder = function(folder, matcher) {
   // Check to see if the folder is actually a file, if so, back up to the
   // parent directory and find some helpers
   folderStats = fs.statSync(folder);
   if (folderStats.isFile()) {
     folder = path.dirname(folder);
   }
+
   var helpers = [],
       helperCollection = require('./spec-collection');
 
   helperCollection.load([folder], matcher);
   helpers = helperCollection.getSpecs();
 
-  for (var i = 0, len = helpers.length; i < len; ++i)
-  {
+  for (var i = 0, len = helpers.length; i < len; ++i) {
     var file = helpers[i].path();
-    var helper= require(file.replace(/\.*$/, ""));
-    for (var key in helper)
+
+    try {
+      var helper = require(file.replace(/\.*$/, ""));
+    } catch (e) {
+      console.log("Exception loading helper: " + file)
+      console.log(e);
+      throw e; // If any of the helpers fail to load, fail everything
+    }
+
+    for (var key in helper) {
       global[key]= helper[key];
+    }
   }
 };
 


### PR DESCRIPTION
If a helper script fails to load, currently jasmine-node immediately and silently dies, with no output. This is very unhelpful! This patch makes it fail fast with the error message & offending file logged to the console (along with some tiny bits of whitespace tidy up)
