### PR TITLE
Don’t affect line numbers with --requireJsSetup

### DIFF
--- a/lib/jasmine-node/requirejs-runner.js
+++ b/lib/jasmine-node/requirejs-runner.js
@@ -67,20 +67,19 @@ exports.executeJsRunner = function(specCollection, done, jasmineEnv, setupFile) 
       };
 
   specCollection.getSpecs().forEach(function(s){
-    var script = fs.readFileSync(s.path(), 'utf8'),
-        wrappedScript;
+    var script = fs.readFileSync(s.path(), 'utf8');
 
     if (s.filename().substr(-6).toLowerCase() == 'coffee') {
       script = coffeescript.compile(script);
     }
 
-    wrappedScript = template + script;
-
     var newContext = buildNewContext(s);
     newContext.setTimeout = jasmine.getGlobal().setTimeout;
     newContext.setInterval = jasmine.getGlobal().setInterval;
 
-    vm.runInNewContext(wrappedScript, newContext, s.path());
+    var vmContext = vm.createContext(newContext);
+    vm.runInContext(template, vmContext);
+    vm.runInContext(script, vmContext, s.path());
   });
 
   specLoader.executeWhenAllSpecsAreComplete(jasmineEnv);


### PR DESCRIPTION
This pull requests runs requireJS setup and spec file consecutively in the same VM context. This way, the line numbers of spec files are not shifted in stack traces.
