### PR TITLE
Fix README.md async timeout interval ms typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ var request = require('request');
 it("should respond with hello world", function(done) {
   request("http://localhost:3000/hello", function(error, response, body){
     done();
-  }, 250);  // timeout after 250 ms
-});
+  });
+}, 250); // timeout after 250 ms
 ```
 
 or


### PR DESCRIPTION
After using the first async example in the README.md and failing to get it to work I re-read the text above it and got it to work by changing the location of the timeout parameter value.
I think it may be a typo in the REDME.

Thanks
