### PR TITLE
Restored growl reporter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ what's new
 *  Rewrote Terminal Reporter
 *  Removed TeamCity Reporter (no support for Jasmine 2.0)
 *  Removed JUnit Reporter (no support for Jasmine 2.0)
-*  Removed Growl Reporter (no support for Jasmine 2.0)
 
 install
 ------

--- a/lib/jasmine-node/cli.js
+++ b/lib/jasmine-node/cli.js
@@ -1,5 +1,5 @@
 (function() {
-  var allowed, args, coffee, dir, error, exitCode, fs, help, helperCollection, jasmine, key, matcher, minimist, minimistOpts, onExit, options, path, printVersion, spec, specFolder, util, value, _, _i, _j, _k, _l, _len, _len1, _len2, _len3, _ref, _ref1, _ref2, _ref3, _ref4,
+  var allowed, args, coffee, dir, error, exitCode, fs, growl, help, helperCollection, jasmine, key, matcher, minimist, minimistOpts, onExit, options, path, printVersion, spec, specFolder, util, value, _, _i, _j, _k, _l, _len, _len1, _len2, _len3, _ref, _ref1, _ref2, _ref3, _ref4,
     __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
 
   util = require('util');
@@ -19,7 +19,7 @@
   helperCollection = require('./spec-collection');
 
   help = function() {
-    process.stdout.write("USAGE: jasmine-node [--color|--noColor] [--verbose] [--coffee] directory\n\nOptions:\n  --autoTest         - rerun automatically the specs when a file changes\n  --watch PATH       - when used with --autoTest, watches the given path(s) and runs all tests if a change is detected\n  --noColor          - do not use color coding for output\n  -m, --match REGEXP - load only specs containing \"REGEXPspec\"\n  --matchAll         - relax requirement of \"spec\" in spec file names\n  --verbose          - print extra information per each test run\n  --coffee           - load coffee-script which allows execution .coffee files\n  --forceExit        - force exit once tests complete.\n  --captureExceptions- listen to global exceptions, report them and exit (interferes with Domains)\n  --noStackTrace     - suppress the stack trace generated from a test failure\n  --version          - show the current version\n  -h, --help         - display this help and exit");
+    process.stdout.write("USAGE: jasmine-node [--color|--noColor] [--verbose] [--coffee] directory\n\nOptions:\n  --autoTest         - rerun automatically the specs when a file changes\n  --watch PATH       - when used with --autoTest, watches the given path(s) and runs all tests if a change is detected\n  --noColor          - do not use color coding for output\n  -m, --match REGEXP - load only specs containing \"REGEXPspec\"\n  --matchAll         - relax requirement of \"spec\" in spec file names\n  --verbose          - print extra information per each test run\n  --growl            - display test run summary in a growl notification (in addition to other outputs)\n  --coffee           - load coffee-script which allows execution .coffee files\n  --forceExit        - force exit once tests complete.\n  --captureExceptions- listen to global exceptions, report them and exit (interferes with Domains)\n  --noStackTrace     - suppress the stack trace generated from a test failure\n  --version          - show the current version\n  -h, --help         - display this help and exit");
     return process.exit(-1);
   };
 
@@ -39,8 +39,10 @@
 
   exitCode = 0;
 
+  growl = false;
+
   minimistOpts = {
-    boolean: ["autoTest", "captureExceptions", "coffee", "forceExit", "matchAll", "noColor", "noStackTrace", "verbose"],
+    boolean: ["autoTest", "captureExceptions", "coffee", "forceExit", "matchAll", "noColor", "noStackTrace", "verbose", "growl"],
     string: ["watch", "m"],
     alias: {
       m: "match"
@@ -53,7 +55,8 @@
       matchAll: false,
       noColor: false,
       noStackTrace: false,
-      verbose: false
+      verbose: false,
+      growl: false
     }
   };
 

--- a/lib/jasmine-node/jasmine-loader.js
+++ b/lib/jasmine-node/jasmine-loader.js
@@ -1,9 +1,11 @@
 (function() {
-  var bootSrc, bootjs, fs, helperCollection, isWindowDefined, jasmine, jasmineSrc, jasminejs, key, mkdirp, nodeReporters, path, print, removeJasmineFrames, specs, util, value, vm, _;
+  var bootSrc, bootjs, fs, growlReporter, helperCollection, isWindowDefined, jasmine, jasmineSrc, jasminejs, key, mkdirp, nodeReporters, path, print, removeJasmineFrames, specs, util, value, vm, _;
 
   _ = require('underscore');
 
   fs = require('fs');
+
+  growlReporter = require('jasmine-growl-reporter');
 
   mkdirp = require('mkdirp');
 
@@ -47,6 +49,8 @@
   }
 
   jasmine.TerminalReporter = nodeReporters.TerminalReporter;
+
+  jasmine.GrowlReporter = growlReporter;
 
   jasmine.loadHelpersInFolder = function(folder, matcher) {
     var e, file, folderStats, help, helper, helpers, key, _i, _len;
@@ -105,6 +109,9 @@
     }
     specs.load(options.specFolders, options.regExpSpec);
     jasmineEnv.addReporter(new jasmine.TerminalReporter(reporterOptions));
+    if (options.growl) {
+      jasmineEnv.addReporter(new jasmine.GrowlReporter(options.growl));
+    }
     specsList = specs.getSpecs();
     for (_i = 0, _len = specsList.length; _i < _len; _i++) {
       spec = specsList[_i];

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "underscore": "~1.6.0",
     "gaze": "~0.5.1",
     "mkdirp": "~0.3.5",
-    "minimist": "0.0.8"
+    "minimist": "0.0.8",
+    "jasmine-growl-reporter": "~0.2.0"
   },
   "devDependencies": {
     "grunt-contrib-coffee": "^0.10.1",

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -20,6 +20,7 @@ Options:
   -m, --match REGEXP - load only specs containing "REGEXPspec"
   --matchAll         - relax requirement of "spec" in spec file names
   --verbose          - print extra information per each test run
+  --growl            - display test run summary in a growl notification (in addition to other outputs)
   --coffee           - load coffee-script which allows execution .coffee files
   --forceExit        - force exit once tests complete.
   --captureExceptions- listen to global exceptions, report them and exit (interferes with Domains)
@@ -30,7 +31,6 @@ Options:
 
 #  --testDir          - the absolute root directory path where tests are located
 #  --config NAME VALUE- set a global variable in process.env
-#  --growl            - display test run summary in a growl notification (in addition to other outputs)
   process.exit -1
 
 printVersion = ->
@@ -44,7 +44,7 @@ jasmine.setInterval = jasmine.getGlobal().setInterval
 global[key] = value for key, value of jasmine
 
 exitCode = 0
-# growl = false
+growl = false
 
 minimistOpts =
     boolean: [
@@ -56,7 +56,7 @@ minimistOpts =
         "noColor"
         "noStackTrace"
         "verbose"
-        # "growl"
+        "growl"
     ]
     string: [
         "watch"
@@ -75,7 +75,7 @@ minimistOpts =
         noColor           : false
         noStackTrace      : false
         verbose           : false
-        # growl             : false
+        growl             : false
 
 args = minimist process.argv.slice(2), minimistOpts
 

--- a/src/jasmine-loader.coffee
+++ b/src/jasmine-loader.coffee
@@ -1,6 +1,6 @@
 _                = require 'underscore'
 fs               = require 'fs'
-#growlReporter    = require 'jasmine-growl-reporter'
+growlReporter    = require 'jasmine-growl-reporter'
 mkdirp           = require 'mkdirp'
 path             = require 'path'
 util             = require 'util'
@@ -32,7 +32,7 @@ jasmine = vm.runInThisContext "#{bootSrc}\njasmine = window.jasmine;", bootjs
 delete global.window unless isWindowDefined
 
 jasmine.TerminalReporter = nodeReporters.TerminalReporter
-# jasmine.GrowlReporter = growlReporter
+jasmine.GrowlReporter = growlReporter
 
 # Define helper functions
 jasmine.loadHelpersInFolder = (folder, matcher) ->
@@ -85,8 +85,8 @@ jasmine.executeSpecsInFolder = (options) ->
 
     jasmineEnv.addReporter new jasmine.TerminalReporter reporterOptions
 
-    # if options.growl?
-    #   jasmineEnv.addReporter new jasmine.GrowlReporter()
+    if options.growl
+      jasmineEnv.addReporter new jasmine.GrowlReporter(options.growl)
 
     specsList = specs.getSpecs()
 


### PR DESCRIPTION
Restoring my growl reporter which I upgraded to be compatible with Jasmine 2.0.

Run `node lib/jasmine-node/cli.js --growl spec` to see it work.

Sorry for the double pull request. I picked the wrong branch earlier.
