### PR TITLE
Added 'onComplete' callback to TeamCityReporter

### DIFF
--- a/lib/jasmine-node/index.js
+++ b/lib/jasmine-node/index.js
@@ -34,6 +34,7 @@ require("jasmine-reporters");
 var nodeReporters = require('./reporter').jasmineNode;
 jasmine.TerminalVerboseReporter = nodeReporters.TerminalVerboseReporter;
 jasmine.TerminalReporter = nodeReporters.TerminalReporter;
+jasmine.TeamcityReporter = nodeReporters.TeamcityReporter;
 jasmine.GrowlReporter = require('jasmine-growl-reporter');
 
 
@@ -123,7 +124,7 @@ jasmine.executeSpecsInFolder = function(options){
   }
 
   if(teamcity){
-    jasmineEnv.addReporter(new jasmine.TeamcityReporter());
+    jasmineEnv.addReporter(new jasmine.TeamcityReporter({onComplete: done}));
   } else if(isVerbose) {
     jasmineEnv.addReporter(new jasmine.TerminalVerboseReporter({ print: print,
                                                          color:       showColors,

--- a/lib/jasmine-node/reporter.js
+++ b/lib/jasmine-node/reporter.js
@@ -322,6 +322,19 @@
   // Inherit from TerminalReporter
   jasmineNode.TerminalVerboseReporter.prototype.__proto__ = jasmineNode.TerminalReporter.prototype;
 
+  // Extend Teamcity Reporter
+  jasmineNode.TeamcityReporter = function(config) {
+    var callback_ = config.onComplete || false;
+
+    (function(superFn) {
+      jasmineNode.TeamcityReporter.prototype.reportRunnerResults = function(runner) {
+        superFn.call(this, runner);
+        if (callback_) {callback_(runner)}
+      }
+    }(jasmine.TeamcityReporter.prototype.reportRunnerResults));
+  };
+  jasmineNode.TeamcityReporter.prototype = new jasmine.TeamcityReporter;
+
   //
   // Exports
   //


### PR DESCRIPTION
fixed missing: TeamcityReporter does not support "onComplete" callback which is used by grunt-jasmine-node to determine the exit code

Without it grunt will always exit with code '0' even for failed tests.
