### PR TITLE
Add additional tests and code in the _contains block to prevent the exce...

### DIFF
--- a/lib/jasmine-node/jasmine-1.3.1.js
+++ b/lib/jasmine-node/jasmine-1.3.1.js
@@ -1085,6 +1085,10 @@ jasmine.Env.prototype.contains_ = function(haystack, needle) {
     }
     return false;
   }
+  if (typeof(haystack) === 'undefined')
+  {
+    return false;
+  }
   return haystack.indexOf(needle) >= 0;
 };
 

--- a/spec/TestSpec.js
+++ b/spec/TestSpec.js
@@ -1,4 +1,29 @@
 
+describe('toContain of undefined', function(){
+  it('should fail but not crash', function(){
+    expect(null).toContain('foo');
+  });
+  it('should fail on undefined by not crash', function(){
+    var foo;
+    expect(foo).toContain('foo');
+  });
+  it('should pass on when string does contain value', function(){
+    var foo='foo';
+    expect(foo).toContain('foo');
+  });
+  it('should fail on when string does not contain value', function(){
+    var foo='bar';
+    expect(foo).toContain('foo');
+  });
+  it('should pass on when array does contain value', function(){
+    var foo= [ 'foo', 'bar' ];
+    expect(foo).toContain('foo');
+  });
+  it('should fail on when array does not contain value', function(){
+    var foo= [ 'bar', 'baz' ];
+    expect(foo).toContain('foo');
+  });
+});
 describe('jasmine-node-flat', function(){
   it('should pass', function(){
     expect(1+2).toEqual(3);

--- a/specs.sh
+++ b/specs.sh
@@ -1,19 +1,25 @@
 #!/usr/bin/env bash
 
-entry="node lib/jasmine-node/cli.js --noStack "
+entry="node lib/jasmine-node/cli.js "
 
 echo "Running all tests located in the spec directory"
 command=$entry"spec"
 echo $command
 time $command #/nested/uber-nested
-echo -e "\033[1;35m--- Should have 59 tests and 104 assertions and 4 Failure. ---\033[0m"
+echo -e "\033[1;35m--- Should have 65 tests and 110 assertions and 8 Failures. ---\033[0m"
 echo ""
 
 echo "Running all tests located in the spec directory with coffee option"
 command=$entry"--coffee spec"
 echo $command
 time $command #/nested/uber-nested
-echo -e "\033[1;35m--- Should have 64 tests and 109 assertions and 6 Failures. ---\033[0m"
+echo -e "\033[1;35m--- Should have 70 tests and 115 assertions and 10 Failures. ---\033[0m"
+
+echo "Running all tests located in the spec directory with forceExit option"
+command=$entry"--forceexit spec"
+echo $command
+time $command #/nested/uber-nested
+echo -e "\033[1;35m--- Should have 65 tests and 110 assertions and 8 Failures. ---\033[0m"
 echo ""
 
 echo "Running all tests located in the spec directory with requirejs option"
@@ -21,17 +27,17 @@ echo "Running all tests located in the spec directory with requirejs option"
 command=$entry"--runWithRequireJs spec"
 echo $command
 time $command
-echo -e "\033[1;35m--- Should have 59 tests and 104 assertions and 4 Failure. ---\033[0m"
+echo -e "\033[1;35m--- Should have 65 tests and 110 assertions and 8 Failures. ---\033[0m"
 echo ""
 
 echo "Running all tests located in the spec-requirejs directory with requirejs, requirejs setup, and coffee option"
 command=$entry"--runWithRequireJs --requireJsSetup spec-requirejs-coffee/requirejs-setup.js --coffee spec-requirejs-coffee"
 echo $command
 time $command
-echo -e "\033[1;35m--- Should have 2 tests and 4 assertions and 0 Failure. ---\033[0m"
+echo -e "\033[1;35m--- Should have 2 tests and 4 assertions and 0 Failures. ---\033[0m"
 
 echo "Running three specs file in the spec directory with coffee option"
 command=$entry"--coffee spec/AsyncSpec.coffee spec/CoffeeSpec.coffee spec/SampleSpecs.js"
 echo $command
 time $command
-echo -e "\033[1;35m--- Should have 3 tests and 3 assertions and 2 Failure. ---\033[0m"
+echo -e "\033[1;35m--- Should have 3 tests and 3 assertions and 2 Failures. ---\033[0m"


### PR DESCRIPTION
This isn't really a bug in jasmine-node, but the exception will cause Grunt to fail with grunt-jasmine-node.

I also added additional tests around the toContain to show more uses.
