### PR TITLE
bug: TeamcityReporter is using undeclared variable

### DIFF
--- a/lib/jasmine-node/reporter.js
+++ b/lib/jasmine-node/reporter.js
@@ -331,9 +331,9 @@
         superFn.call(this, runner);
         if (callback_) {callback_(runner)}
       }
-    }(jasmine.TeamcityReporter.prototype.reportRunnerResults));
+    }(jasmineNode.TeamcityReporter.prototype.reportRunnerResults));
   };
-  jasmineNode.TeamcityReporter.prototype = new jasmine.TeamcityReporter;
+  jasmineNode.TeamcityReporter.prototype = new jasmineNode.TeamcityReporter;
 
   //
   // Exports


### PR DESCRIPTION
TeamcityReporter is using jasmine instead of jasmineNode in two places. This is causes the TeamcityReporter to fail for the latest version of jasmine-node.
