### PR TITLE
Use 1.x branch for Jasmine-Reporters

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "coffee-script": ">=1.0.1",
-    "jasmine-reporters": ">=0.2.0",
+    "jasmine-reporters": "<2.0.0",
     "jasmine-growl-reporter": "~0.0.2",
     "requirejs": ">=0.27.1",
     "walkdir": ">= 0.0.1",


### PR DESCRIPTION
Make sure jasmine-reporters works off the jasmine1.x branch.

Due to: https://github.com/larrymyers/jasmine-reporters/issues/52 and how `jasmine-node` is specifying the version for `jasmine-reporters`, it is now pulling in the 2.0 version of `jasmine-reporters`. This patch limits `jasmine-reporters` to the 1.x branch, which keeps `jasmine-node` working.
