### PR TITLE
jasmine-reporters version changed to 0.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "coffee-script": ">=1.0.1",
-    "jasmine-reporters": ">=0.2.0",
+    "jasmine-reporters": "0.x.x",
     "jasmine-growl-reporter": "~0.0.2",
     "requirejs": ">=0.27.1",
     "walkdir": ">= 0.0.1",


### PR DESCRIPTION
Recently a new version of jasmine-reporters (2.0.0) has been released which is incompatible with 0.x.x version. Due to version range ">=0.2.0" the latest version gets installed causing jasmine to fail. Following error can be observed:

{project-path}/node_modules/jasmine-node/lib/jasmine-node/reporter.js:336
  jasmineNode.TeamcityReporter.prototype = new jasmine.TeamcityReporter;
                                           ^
TypeError: undefined is not a function
