### PR TITLE
Updated package.json with jasmine-reporters to use compatible version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "coffee-script": ">=1.0.1",
-    "jasmine-reporters": ">=0.2.0",
+    "jasmine-reporters": "~0.4.1",
     "jasmine-growl-reporter": "~0.0.2",
     "requirejs": ">=0.27.1",
     "walkdir": ">= 0.0.1",


### PR DESCRIPTION
Noticed version of jasmine-reporters@2.0.0 is breaking jasmine-node
