### PR TITLE
Downgrade Jasmine Reporters to v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "coffee-script": ">=1.0.1",
-    "jasmine-reporters": "^0.4.0",
+    "jasmine-reporters": "^1.0.0",
     "jasmine-growl-reporter": "~0.0.2",
     "requirejs": ">=0.27.1",
     "walkdir": ">= 0.0.1",


### PR DESCRIPTION
Another variation of the fix for #330, #334, #336. This supports v1 and its minor revision and patches.
