### PR TITLE
remove magic number from version output

### DIFF
--- a/lib/jasmine-node/cli.js
+++ b/lib/jasmine-node/cli.js
@@ -3,6 +3,7 @@ var util,
     fs  = require('fs');
 
 var jasmine = require('./index');
+var version = require('../../package').version;
 
 
 try {
@@ -282,6 +283,6 @@ function help(){
 }
 
 function printVersion(){
-  console.log("1.14.3");
+  console.log(version);
   process.exit(0);
 }


### PR DESCRIPTION
Replaces harded-coded version number with value from `package.json`.
