### PR TITLE
Show stacktraces from exceptions that occur at require() time

### DIFF
--- a/lib/jasmine-node/index.js
+++ b/lib/jasmine-node/index.js
@@ -160,7 +160,7 @@ jasmine.executeSpecsInFolder = function(options){
         require(filename.path().replace(/\.\w+$/, ""));
       } catch (e) {
         console.log("Exception loading: " + filename.path());
-        console.log(e);
+        console.log(e.stack);
         throw e;
       }
     }


### PR DESCRIPTION
If a spec throws an exception at `require()` time we don't get the full stack trace. This makes debugging a nontrivial project hugely difficult. This changes `jasmine-node` to report the full stacktrace.
