### PR TITLE
Fix version number to match npm package version

### DIFF
--- a/lib/jasmine-node/cli.js
+++ b/lib/jasmine-node/cli.js
@@ -282,6 +282,6 @@ function help(){
 }
 
 function printVersion(){
-  console.log("1.14.3");
+  console.log("1.14.5");
   process.exit(0);
 }


### PR DESCRIPTION
Executing `jasmine-node --version` prints out `1.14.3`, while npm package version is `1.14.5`. This PR updates reported version to match that of the npm package.

This references #350 
