### PR TITLE
Update cli.js, added --extensions cli arg

### DIFF
--- a/lib/jasmine-node/cli.js
+++ b/lib/jasmine-node/cli.js
@@ -67,6 +67,9 @@ while(args.length) {
     case '--verbose':
       isVerbose = true;
       break;
+    case '--extensions':
+      extensions = args.shift();
+      break;
     case '--coffee':
       try {
         require('coffee-script/register'); // support CoffeeScript >=1.7.0
@@ -260,7 +263,8 @@ function help(){
   , '  -m, --match REGEXP - load only specs containing "REGEXPspec"'
   , '  --matchall         - relax requirement of "spec" in spec file names'
   , '  --verbose          - print extra information per each test run'
-  , '  --coffee           - load coffee-script which allows execution .coffee files'
+  , '  --extensions REGEX - load only files with REGEX file name extensions, e.g. (js|jsx)'
+  , '  --coffee           - load coffee-script which allows execution .coffee files, overrides --extensions'
   , '  --junitreport      - export tests results as junitreport xml format'
   , '  --output           - defines the output folder for junitreport files'
   , '  --teamcity         - converts all console output to teamcity custom test runner commands. (Normally auto detected.)'

--- a/lib/jasmine-node/cli.js
+++ b/lib/jasmine-node/cli.js
@@ -178,11 +178,10 @@ if (specFolders.length === 0) {
 }
 
 if (autotest) {
-  
-  var patterns = ['**/*.js'];
-  
-  if (extensions.indexOf("coffee") !== -1) {
-    patterns.push('**/*.coffee');
+
+  var patterns = extensions.split('\|');
+  for (var idx = 0; idx < patterns.length; idx++) {
+    patterns[idx] = '**/*.' + patterns[idx];
   }
 
   require('./autotest').start(specFolders, watchFolders, patterns);


### PR DESCRIPTION
When using Webpack's enhanced-require, .jsx files can be transformed into .js files by require(), so it would be useful to support choosing arbitrary file name extensions (e.g. allow for (js|jsx))

Please consider merging

[edit]: here's a workaround to also include .jsx spec files, but it does not look very pretty as --extensions "js|jsx" would:
      --matchall --match "(jsx?)$|"
