### PR TITLE
NodeJS deprecation warnings on util.puts

### DIFF
--- a/lib/jasmine-node/index.js
+++ b/lib/jasmine-node/index.js
@@ -115,7 +115,7 @@ jasmine.executeSpecsInFolder = function(options){
   if(junitreport && junitreport.report) {
     var existsSync = fs.existsSync || path.existsSync;
     if(!existsSync(junitreport.savePath)) {
-      util.puts('creating junit xml report save path: ' + junitreport.savePath);
+      console.log('creating junit xml report save path: ' + junitreport.savePath);
       mkdirp.sync(junitreport.savePath, "0755");
     }
     jasmineEnv.addReporter(new jasmine.JUnitXmlReporter(junitreport.savePath,


### PR DESCRIPTION
`util.puts` will sometimes cause node to issue deprecation warnings to stderr complaining that it's been deprecated and asking to use `console.log` in its favor.