### PR TITLE
Upgrade gaze version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "requirejs": ">=0.27.1",
     "walkdir": ">= 0.0.1",
     "underscore": ">= 1.3.1",
-    "gaze": "~0.3.2",
+    "gaze": ">=1.1.2",
     "mkdirp": "~0.3.5"
   },
   "bin": "bin/jasmine-node",


### PR DESCRIPTION
Upgrade gaze version because the actual uses a version of `minimatch` that may cause a [RegExp DoS issue](https://github.com/npm/npm/issues/13323).

Closes #411