### PR TITLE
Switch to coffeescript package

### DIFF
--- a/lib/jasmine-node/cli.js
+++ b/lib/jasmine-node/cli.js
@@ -69,9 +69,9 @@ while(args.length) {
       break;
     case '--coffee':
       try {
-        require('coffee-script/register'); // support CoffeeScript >=1.7.0
+        require('coffeescript/register'); // support CoffeeScript >=1.7.0
       } catch ( e ) {
-        require('coffee-script'); // support CoffeeScript <=1.6.3
+        require('coffeescript'); // support CoffeeScript <=1.6.3
       }
       extensions = "js|coffee|litcoffee";
       break;
@@ -260,7 +260,7 @@ function help(){
   , '  -m, --match REGEXP - load only specs containing "REGEXPspec"'
   , '  --matchall         - relax requirement of "spec" in spec file names'
   , '  --verbose          - print extra information per each test run'
-  , '  --coffee           - load coffee-script which allows execution .coffee files'
+  , '  --coffee           - load coffeescript which allows execution .coffee files'
   , '  --junitreport      - export tests results as junitreport xml format'
   , '  --output           - defines the output folder for junitreport files'
   , '  --teamcity         - converts all console output to teamcity custom test runner commands. (Normally auto detected.)'

--- a/lib/jasmine-node/cs.js
+++ b/lib/jasmine-node/cs.js
@@ -8,7 +8,7 @@
 /*global define, window, XMLHttpRequest, importScripts, Packages, java,
   ActiveXObject, process, require */
 
-define(['coffee-script'], function (CoffeeScript) {
+define(['coffeescript'], function (CoffeeScript) {
     'use strict';
     var fs, getXhr,
         progIds = ['Msxml2.XMLHTTP', 'Microsoft.XMLHTTP', 'Msxml2.XMLHTTP.4.0'],

--- a/lib/jasmine-node/requirejs-runner.js
+++ b/lib/jasmine-node/requirejs-runner.js
@@ -4,7 +4,7 @@ exports.executeJsRunner = function(specCollection, done, jasmineEnv, setupFile) 
       requirejs = require('requirejs'),
       vm = require('vm'),
       fs = require('fs'),
-      coffeescript = require('coffee-script'),
+      coffeescript = require('coffeescript'),
       template = fs.readFileSync(
         setupFile || (__dirname + '/requirejs-wrapper-template.js'),
         'utf8'

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "MIT"
   ],
   "dependencies": {
-    "coffee-script": ">=1.0.1",
+    "coffeescript": ">=1.0.1",
     "jasmine-reporters": "~1.0.0",
     "jasmine-growl-reporter": "~0.0.2",
     "requirejs": ">=0.27.1",


### PR DESCRIPTION
Switch to `coffeescript` package instead of deprecated `coffee-script`:
```
npm WARN deprecated coffee-script@1.12.7: CoffeeScript on NPM has moved to "coffeescript" (no hyphen)
```