### PR TITLE
update gaz to 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "requirejs": ">=0.27.1",
     "walkdir": ">= 0.0.1",
     "underscore": ">= 1.3.1",
-    "gaze": "~0.3.2",
+    "gaze": "~1.1.2",
     "mkdirp": "~0.3.5"
   },
   "bin": "bin/jasmine-node",


### PR DESCRIPTION
Update gaz to 1.1.2 to avoid potential Dos issue with deprecated version of `minimatch`.
Previously multiple warning were presents:
```
npm WARN deprecated minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated minimatch@0.4.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
```