### PR TITLE
[EMERGENCY] fix: upgrade jasmine-growl-reporter to resolve critical vulnerabirity of growl

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "coffeescript": "~1.12.7",
     "gaze": "~1.1.2",
-    "jasmine-growl-reporter": "~0.2.0",
+    "jasmine-growl-reporter": "^2.0.0",
     "jasmine-reporters": "~1.0.0",
     "mkdirp": "~0.3.5",
     "requirejs": "~2.3.6",


### PR DESCRIPTION
`growl` in dependency through `jasmine-gworl-reporter` has CRITICAL vulnerabirity by `$ npm audit`.
So I resolved it.