### PR TITLE
Make --version show the same value inside package.json

### DIFF
--- a/lib/jasmine-node/cli.js
+++ b/lib/jasmine-node/cli.js
@@ -175,9 +175,8 @@ if (specFolders.length === 0) {
 }
 
 if (autotest) {
-  
   var patterns = ['**/*.js'];
-  
+
   if (extensions.indexOf("coffee") !== -1) {
     patterns.push('**/*.coffee');
   }
@@ -282,6 +281,7 @@ function help(){
 }
 
 function printVersion(){
-  console.log("1.14.?");
+  const package = require(__dirname + '/../../package.json')
+  console.log(package.version);
   process.exit(0);
 }


### PR DESCRIPTION
The CLI flag "--version" wasn't showing the right version of the package.

It had a hardcoded version number that needed to be changed along with the one inside package.json and some time ago people stopped updating it.

This implementation ensures the "--version" flag always report the same value inside package.json, without any need for manually updating.

This supersedes #367.
Fixes #350.