### PR TITLE
Version 3 update

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 The MIT License
 
+Copyright (c) 2018-present Christopher J. Brody and other contributors
 Copyright (c) 2010 Adam Abrons and Misko Hevery http://getangular.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ Version `1.3.1` of Jasmine is currently included with node-jasmine. This is a fo
 
 NOTICE: BETA `2.0.0` Support in the `Jasmine2.0` branch (with rewrite in CoffeeScript) is now abandoned and no longer supported.
 
+Supported Node.js versions
+--------------------------
+
+* Current:
+  - 10
+  - 12
+* Deprecated:
+  - 8 (EOL in December 2019)
+  - 6 (already past EOL)
+  - 4 (already past EOL)
+
+Older versions of Node.js are no longer supported. It is *highly* recommended to upgrade to a supported version of Node.js.
+
 what's new
 ----------
 *  Growl notifications with the `--growl` flag (requires Growl to be installed)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 jasmine-node
 ======
 
+[![LICENSE](https://img.shields.io/github/license/mhevery/jasmine-node.svg?style=flat-square)](./LICENSE)
+[![npm](https://img.shields.io/npm/v/jasmine-node.svg?style=flat-square)](https://www.npmjs.com/package/jasmine-node)
+[![contributors](https://img.shields.io/badge/contributors-many-purple.svg?style=flat-square)](https://github.com/mhevery/jasmine-node/graphs/contributors)
 
 This node.js module makes the wonderful [Pivotal Lab's jasmine](http://github.com/pivotal/jasmine)
 spec framework (version 1) available in node.js.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 jasmine-node
 ======
 
-[![Build Status](https://secure.travis-ci.org/spaghetticode/jasmine-node.png)](http://travis-ci.org/spaghetticode/jasmine-node)
 
 This node.js module makes the wonderful [Pivotal Lab's jasmine](http://github.com/pivotal/jasmine)
 spec framework (version 1) available in node.js.

--- a/lib/jasmine-node/cli.js
+++ b/lib/jasmine-node/cli.js
@@ -175,9 +175,8 @@ if (specFolders.length === 0) {
 }
 
 if (autotest) {
-  
   var patterns = ['**/*.js'];
-  
+
   if (extensions.indexOf("coffee") !== -1) {
     patterns.push('**/*.coffee');
   }
@@ -282,6 +281,7 @@ function help(){
 }
 
 function printVersion(){
-  console.log("1.14.?");
+  const package = require(__dirname + '/../../package.json')
+  console.log(package.version);
   process.exit(0);
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "coffeescript": "~1.12.7",
     "gaze": "~1.1.2",
-    "jasmine-growl-reporter": "~0.2.0",
+    "jasmine-growl-reporter": "~2.0.0",
     "jasmine-reporters": "~1.0.0",
     "mkdirp": "~0.3.5",
     "requirejs": "~2.3.6",

--- a/package.json
+++ b/package.json
@@ -12,11 +12,6 @@
     "bdd"
   ],
   "author": "Misko Hevery <misko@hevery.com>",
-  "maintainers": [
-    "Christopher J. Brody (@brodybits aka Chris Brody) <chris.brody@gmail.com>",
-    "Martin Häger <martin.haeger@gmail.com>",
-    "Chris Moultrie <chris@moultrie.org>"
-  ],
   "license": "MIT",
   "dependencies": {
     "coffeescript": "~1.12.7",

--- a/package.json
+++ b/package.json
@@ -2,11 +2,6 @@
   "name": "jasmine-node",
   "version": "3.0.0-dev",
   "description": "DOM-less simple JavaScript BDD testing framework for Node",
-  "contributors": [
-    "Martin Häger <martin.haeger@gmail.com>",
-    "Chris Moultrie <chris@moultrie.org>",
-    "Christopher J. Brody (@brodybits aka Chris Brody) <chris.brody@gmail.com>"
-  ],
   "homepage": "https://github.com/mhevery/jasmine-node",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jasmine-node",
-  "version": "1.16.2",
+  "version": "3.0.0-dev",
   "description": "DOM-less simple JavaScript BDD testing framework for Node",
   "contributors": [
     "Martin Häger <martin.haeger@gmail.com>",


### PR DESCRIPTION
Includes the following changes:

- PR #439 - update `jasmine-growl-reporter` (note that this is known to fail on Node.js versions 0.8, 0.10, and 0.12, which makes it a major update)
- PR #441 - fix output of `--version` option
- remove `contributors` & `maintainers` from `package.json`
- __Some documentation updates:__
  - _Update copyright in LICENSE_
  - _supported Node.js versions_
  - _remove obsolete build status badge_
  - _add some new badges_