### PR TITLE
[DRAFT MAJOR WIP] Add Node.js engines field which drops old Node.js versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
   ],
   "author": "Misko Hevery <misko@hevery.com>",
   "license": "MIT",
+  "engines": {
+    "node": ">= 8.0.0"
+  },
   "dependencies": {
     "coffeescript": "~1.12.7",
     "gaze": "~1.1.2",


### PR DESCRIPTION
This should be in an another new major release as tracked in #436, drops support for Node.js pre-8.0